### PR TITLE
Small quality of life improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
     <head>
         <meta charset="UTF-8" />
         <title>Quiz Bowl Reader</title>

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -177,7 +177,6 @@ const ExportSettingsDialogBody = observer(
                     autoFocus={true}
                 />
                 <SpinButton
-                    defaultValue={"1"}
                     label="Round Number"
                     onIncrement={roundNumberIncrementHandler}
                     onDecrement={roundNumberDecrementHandler}

--- a/src/components/NewGameDialog.tsx
+++ b/src/components/NewGameDialog.tsx
@@ -385,6 +385,9 @@ function onSubmit(props: INewGameDialogProps): void {
     game.addPlayers(secondTeamPlayers.filter((player) => player.name !== ""));
     game.loadPacket(pendingNewGame.packet);
 
+    // If we've just started a new game, start at the beginning
+    props.appState.uiState.setCycleIndex(0);
+
     hideDialog(props);
 }
 

--- a/src/components/QuestionWord.tsx
+++ b/src/components/QuestionWord.tsx
@@ -54,6 +54,8 @@ const getClassNames = memoizeFunction(
                         background: "rgba(128, 128, 128, 0.2)",
                         textDecoration: "underline double",
                     },
+                // Only highlight a word on hover if it's not in an existing state from selected/correct/wrong
+                !(selected || correct || wrong) && { "&:hover": { background: "rgba(200, 200, 0, 0.15)" } },
             ],
         })
 );


### PR DESCRIPTION
Add some small quality of life improvements and fixes

- Always go to the first cycle when starting a new game
- Highlight words on hover with a yellow background. This needs to be given lower precedence. (#9)
- Redo the error experience so users can export their cycles (as JSON) before resetting the app
    - This also means we can get rid of the clear state button
- Add lang="en" to html to fix Chromium warning
- Remove defaultValue setting from SpinButton to fix warning (#5)