### PR TITLE
Fix bugs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Introduction
 
-This is a tool for reading, scorekeeping, and tracking buzz poins for quiz bowl matches.
+This is a tool for reading, scorekeeping, and tracking buzz points for quiz bowl matches.
+
+See [the wiki](https://github.com/alopezlago/QuizBowlReader/wiki) to learn how to use the reader.
 
 # Getting Started
 

--- a/src/components/PacketLoader.tsx
+++ b/src/components/PacketLoader.tsx
@@ -31,9 +31,7 @@ export const PacketLoader = observer(
                 <Label required={true}>Load Packet</Label>
                 <input
                     type="file"
-                    accept={
-                        ".json,.docx,application/json,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                    }
+                    accept={"application/json,application/vnd.openxmlformats-officedocument.wordprocessingml.document"}
                     ref={fileInput}
                     onChange={uploadHandler}
                 />


### PR DESCRIPTION
- Fix issue where the app would break if we threw out the last bonus (#19)
  - We needed to fix the logic for deciding if a bonus can be protested
- Fix issue where docx/json appeared twice in file dialog in packet loader
- Order buzz points numerically instead of by team (#24)
- Reorder the Export... menu
- Fix typo in README
- Link to wiki in README