### PR TITLE
Various protest improvements + no penalty buzz deserialization fix

### DIFF
--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -69,7 +69,6 @@ function getPlayerMenuItems(props: IBuzzMenuProps, teamName: string): IContextua
                     CompareUtils.playersEqual(buzz.marker.player, player) && buzz.marker.position === props.position
             ) >= 0;
         const isProtestChecked: boolean =
-            isWrongChecked &&
             props.cycle.tossupProtests?.findIndex((protest) => protest.position === props.position) != undefined;
 
         const buzzMenuItemData: IBuzzMenuItemData = { props, player };
@@ -93,7 +92,7 @@ function getPlayerMenuItems(props: IBuzzMenuProps, teamName: string): IContextua
             },
         ];
 
-        if (isWrongChecked) {
+        if (isWrongChecked || isCorrectChecked) {
             subMenuItems.push({
                 key: `${topLevelKey}_protest`,
                 text: "Protest",

--- a/src/components/cycleItems/BonusProtestCycleItem.tsx
+++ b/src/components/cycleItems/BonusProtestCycleItem.tsx
@@ -10,7 +10,16 @@ export const BonusProtestCycleItem = observer(
         const deleteHandler = () => {
             props.cycle.removeBonusProtest(props.protest.partIndex);
         };
-        const text = `${props.protest.teamName} protests bonus #${props.protest.questionIndex + 1}, part ${
+
+        // If the bonus part was correct, the team isn't protesting themselves. To futureproof us from dealing with the
+        // 3+ team case, call it "the other team"
+        const teamName: string =
+            props.cycle.bonusAnswer != undefined &&
+            props.cycle.bonusAnswer?.correctParts.findIndex((part) => part.index === props.protest.partIndex) >= 0
+                ? "The other team"
+                : props.protest.teamName;
+
+        const text = `${teamName} protests bonus #${props.protest.questionIndex + 1}, part ${
             props.protest.partIndex + 1
         }`;
 

--- a/src/components/cycleItems/TossupProtestCycleItem.tsx
+++ b/src/components/cycleItems/TossupProtestCycleItem.tsx
@@ -11,10 +11,8 @@ export const TossupProtestCycleItem = observer(
             props.cycle.removeTossupProtest(props.protest.teamName);
         };
 
-        // If the buzz was correct, the team name should be the other team.
-        // If for some reason we can't find another team, we have to default to the team we were given
-        // TODO: Handle this for the non 2-team case, if we ever decide to generalize this to multiple teams. This means
-        // the dialog will need a dropdown when protesting a correct buzz
+        // If the buzz was correct, the team isn't protesting themselves. To futureproof us from dealing with the 3+
+        // team case, call it "the other team"
         const teamName: string =
             props.cycle.correctBuzz?.marker.player.teamName === props.protest.teamName
                 ? "The other team"

--- a/src/components/cycleItems/TossupProtestCycleItem.tsx
+++ b/src/components/cycleItems/TossupProtestCycleItem.tsx
@@ -11,7 +11,16 @@ export const TossupProtestCycleItem = observer(
             props.cycle.removeTossupProtest(props.protest.teamName);
         };
 
-        const text = `${props.protest.teamName} protests tossup #${props.protest.questionIndex + 1} at word ${
+        // If the buzz was correct, the team name should be the other team.
+        // If for some reason we can't find another team, we have to default to the team we were given
+        // TODO: Handle this for the non 2-team case, if we ever decide to generalize this to multiple teams. This means
+        // the dialog will need a dropdown when protesting a correct buzz
+        const teamName: string =
+            props.cycle.correctBuzz?.marker.player.teamName === props.protest.teamName
+                ? "The other team"
+                : props.protest.teamName;
+
+        const text = `${teamName} protests tossup #${props.protest.questionIndex + 1} at word ${
             props.protest.position + 1
         }`;
         return <CycleItem text={text} onDelete={deleteHandler} />;

--- a/src/state/Cycle.ts
+++ b/src/state/Cycle.ts
@@ -292,13 +292,11 @@ export class Cycle implements ICycle {
     public getProtestableBonusPartIndexes(bonusPartsCount: number): number[] {
         const indexes: number[] = [];
 
-        const protestIndexes: number[] = this.bonusProtests?.map((protest) => protest.partIndex) ?? [];
-        const protestedOrCorrectIndexes: number[] =
-            this.bonusAnswer?.correctParts.map((part) => part.index).concat(protestIndexes) ?? protestIndexes;
-        const protestedOrCorrectIndexesSet = new Set(protestedOrCorrectIndexes);
+        const protestedIndexes: number[] = this.bonusProtests?.map((protest) => protest.partIndex) ?? [];
+        const protestedIndexesSet = new Set(protestedIndexes);
 
         for (let i = 0; i < bonusPartsCount; i++) {
-            if (!protestedOrCorrectIndexesSet.has(i)) {
+            if (!protestedIndexesSet.has(i)) {
                 indexes.push(i);
             }
         }

--- a/src/state/Cycle.ts
+++ b/src/state/Cycle.ts
@@ -77,6 +77,7 @@ export class Cycle implements ICycle {
             this.bonusAnswer = deserializedCycle.bonusAnswer;
             this.bonusProtests = deserializedCycle.bonusProtests;
             this.correctBuzz = deserializedCycle.correctBuzz;
+            this.noPenaltyBuzzes = deserializedCycle.noPenaltyBuzzes;
             this.negBuzz = deserializedCycle.negBuzz;
             this.playerJoins = deserializedCycle.playerJoins;
             this.playerLeaves = deserializedCycle.playerLeaves;


### PR DESCRIPTION
- Add various protest improvements
    - Correctly judged tossups and bonus parts can be protested (#47)
- Readers can protest tossups from the game bar (top menu) (#42)
- Fix issue where no penalty buzzes weren't deserialized, which meant we lost them if the page refreshed (#51)