### PR TITLE
Merged PR 183: Support for powers + Help dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
         "buildRelease": "webpack --mode production",
         "lint": "eslint . --ext .ts,.tsx",
         "start": "webpack serve --color --config webpack.config.js --mode development",
-        "test": "mocha --recursive tests/**/*.ts --exit --check-leaks -r ts-node/register -r tsconfig-paths/register"
+        "test": "mocha --recursive tests/**/*.ts --exit --check-leaks -r tests/TestInit.js -r ts-node/register -r tsconfig-paths/register"
     }
 }

--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -146,7 +146,7 @@ function onCorrectClicked(
             {
                 player,
                 position: item.data.props.position,
-                correct: true,
+                points: props.tossup.getPointsAtPosition(props.appState.game.gameFormat, item.data.props.position),
             },
             props.tossupNumber - 1,
             props.bonusIndex
@@ -171,7 +171,7 @@ function onWrongClicked(
         const marker: IBuzzMarker = {
             player,
             position: props.position,
-            correct: false,
+            points: 0,
         };
 
         // If we're at the end of the question, or if there's already been a neg from a different team, then make it a
@@ -182,6 +182,7 @@ function onWrongClicked(
         ) {
             props.cycle.addNoPenaltyBuzz(marker, props.tossupNumber - 1);
         } else {
+            marker.points = props.appState.game.gameFormat.negValue;
             props.cycle.addNeg(marker, props.tossupNumber - 1);
         }
     }

--- a/src/components/EventViewer.tsx
+++ b/src/components/EventViewer.tsx
@@ -7,6 +7,7 @@ import { mergeStyleSets } from "@fluentui/react";
 import { CycleItemList } from "./cycleItems/CycleItemList";
 import { Cycle } from "src/state/Cycle";
 import { AppState } from "src/state/AppState";
+import { IGameFormat } from "src/state/IGameFormat";
 
 const numberKey = "number";
 const cycleKey = "cycle";
@@ -23,13 +24,16 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
         [props.appState.uiState]
     );
 
-    const renderColumnHandler = React.useCallback((item?: Cycle, index?: number, column?: IColumn): JSX.Element => {
-        if (item === undefined || index === undefined || column === undefined) {
-            return <></>;
-        }
+    const renderColumnHandler = React.useCallback(
+        (item?: Cycle, index?: number, column?: IColumn): JSX.Element => {
+            if (item === undefined || index === undefined || column === undefined) {
+                return <></>;
+            }
 
-        return onRenderItemColumn(item, index, column);
-    }, []);
+            return onRenderItemColumn(item, props.appState.game.gameFormat, index, column);
+        },
+        [props]
+    );
 
     const columns: IColumn[] = [
         {
@@ -72,7 +76,7 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
     );
 });
 
-function onRenderItemColumn(item: Cycle, index: number, column: IColumn): JSX.Element {
+function onRenderItemColumn(item: Cycle, gameFormat: IGameFormat, index: number, column: IColumn): JSX.Element {
     switch (column?.key) {
         case numberKey:
             if (index == undefined) {
@@ -86,7 +90,7 @@ function onRenderItemColumn(item: Cycle, index: number, column: IColumn): JSX.El
 
             return (
                 <>
-                    <CycleItemList cycle={item} />
+                    <CycleItemList cycle={item} gameFormat={gameFormat} />
                     <Label>{`(${scoreInCurrentCycle[0]} - ${scoreInCurrentCycle[1]})`}</Label>
                 </>
             );

--- a/src/components/FormattedText.tsx
+++ b/src/components/FormattedText.tsx
@@ -21,6 +21,10 @@ const FormattedSegment = observer((props: IFormattedSegmentProps) => {
     // I used inline styles with divs for each individual element, but that messes up kerning when punctuation
     // following the text has a different format. Basic formatting tags (<b>, <u>, <i>) will keep them together.
     let element: JSX.Element = <>{props.segment.text}</>;
+    if (props.segment.bolded) {
+        element = <b>{element}</b>;
+    }
+
     if (props.segment.emphasized) {
         element = <i>{element}</i>;
     }

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -55,6 +55,8 @@ export const GameBar = observer(
             uiState.createPendingNewPlayer(game.teamNames[0]);
         }, [uiState, game]);
 
+        const openHelpHandler = React.useCallback(() => props.appState.uiState.dialogState.showHelpDialog(), [props]);
+
         const items: ICommandBarItemProps[] = [
             {
                 key: "newGame",
@@ -114,7 +116,11 @@ export const GameBar = observer(
             },
         });
 
-        // Get the actions, and decide if there are any applicable ones
+        items.push({
+            key: "help",
+            text: "Help...",
+            onClick: openHelpHandler,
+        });
 
         return <CommandBar items={items} overflowButtonProps={overflowProps} />;
     }

--- a/src/components/ModalDialogContainer.tsx
+++ b/src/components/ModalDialogContainer.tsx
@@ -8,6 +8,7 @@ import { ExportToSheetsDialog } from "./dialogs/ExportToSheetsDialog";
 import { ExportToJsonDialog } from "./dialogs/ExportToJsonDialog";
 import { ImportGameDialog } from "./dialogs/ImportGameDialog";
 import { FontDialog } from "./dialogs/FontDialog";
+import { HelpDialog } from "./dialogs/HelpDialog";
 
 export const ModalDialogContainer = observer((props: IModalDialogContainerProps) => {
     // The Protest dialogs aren't here because they require extra information
@@ -17,6 +18,7 @@ export const ModalDialogContainer = observer((props: IModalDialogContainerProps)
             <ExportToJsonDialog appState={props.appState} />
             <ExportToSheetsDialog appState={props.appState} />
             <FontDialog appState={props.appState} />
+            <HelpDialog appState={props.appState} />
             <ImportGameDialog appState={props.appState} />
             <NewGameDialog appState={props.appState} />
         </>

--- a/src/components/QuestionWord.tsx
+++ b/src/components/QuestionWord.tsx
@@ -7,10 +7,10 @@ import { FormattedText } from "./FormattedText";
 
 export const QuestionWord = observer(
     (props: IQuestionWordProps): JSX.Element => {
-        const classes = getClassNames(props.selected, props.correct, props.wrong);
+        const classes = getClassNames(props.selected, props.correct, props.wrong, props.index != undefined);
 
         return (
-            <span ref={props.componentRef} data-value={props.index} className={classes.word}>
+            <span ref={props.componentRef} data-index={props.index} className={classes.word}>
                 <FormattedText segments={props.word} />
             </span>
         );
@@ -19,7 +19,7 @@ export const QuestionWord = observer(
 
 interface IQuestionWordProps {
     word: IFormattedText[];
-    index: number;
+    index: number | undefined;
     selected?: boolean;
     correct?: boolean;
     wrong?: boolean;
@@ -33,7 +33,12 @@ interface IQuestionWordClassNames {
 
 // This would be a great place for theming or settings
 const getClassNames = memoizeFunction(
-    (selected?: boolean, correct?: boolean, wrong?: boolean): IQuestionWordClassNames =>
+    (
+        selected: boolean | undefined,
+        correct: boolean | undefined,
+        wrong: boolean | undefined,
+        isIndexDefined: boolean
+    ): IQuestionWordClassNames =>
         mergeStyleSets({
             word: [
                 { display: "inline-flex" },
@@ -55,7 +60,8 @@ const getClassNames = memoizeFunction(
                         textDecoration: "underline double",
                     },
                 // Only highlight a word on hover if it's not in an existing state from selected/correct/wrong
-                !(selected || correct || wrong) && { "&:hover": { background: "rgba(200, 200, 0, 0.15)" } },
+                isIndexDefined &&
+                    !(selected || correct || wrong) && { "&:hover": { background: "rgba(200, 200, 0, 0.15)" } },
             ],
         })
 );

--- a/src/components/cycleItems/CycleItemList.tsx
+++ b/src/components/cycleItems/CycleItemList.tsx
@@ -20,10 +20,11 @@ import { ThrowOutQuestionCycleItem } from "./ThrowOutQuestionCycleItem";
 import { BonusAnswerCycleItem } from "./BonusAnswerCycleItem";
 import { TossupProtestCycleItem } from "./TossupProtestCycleItem";
 import { BonusProtestCycleItem } from "./BonusProtestCycleItem";
+import { IGameFormat } from "src/state/IGameFormat";
 
 export const CycleItemList = observer(
     (props: ICycleItemListProps): JSX.Element => {
-        return <div>{createCycleList(props.cycle)}</div>;
+        return <div>{createCycleList(props.cycle, props.gameFormat)}</div>;
     }
 );
 
@@ -31,7 +32,7 @@ export const CycleItemList = observer(
 // TODO: Investigate using List/DetailedList for this, instead of returning a bunch of individual elements
 // Consider making CycleItem take in a "data" field, that can be passed into the click handler. This will solve the
 // issue of making a new event handler each time
-function createCycleList(cycle: Cycle): JSX.Element[] {
+function createCycleList(cycle: Cycle, gameFormat: IGameFormat): JSX.Element[] {
     // Ordering should be
     // Substitutions
     // Buzzes and thrown out tossups, based on the tossup index. If a thrown out tossup and buzz have the same index,
@@ -104,7 +105,7 @@ function createCycleList(cycle: Cycle): JSX.Element[] {
                 }
             }
 
-            elements.push(createTossupAnswerDetails(cycle, buzz, i));
+            elements.push(createTossupAnswerDetails(cycle, buzz, gameFormat, i));
         }
 
         // Ordering is still a little off, and the buzzes remain in view. Tweak this.
@@ -175,13 +176,19 @@ function createSubstitutionDetails(cycle: Cycle, sub: ISubstitutionEvent, index:
     );
 }
 
-function createTossupAnswerDetails(cycle: Cycle, buzz: ITossupAnswerEvent, buzzIndex: number): JSX.Element {
+function createTossupAnswerDetails(
+    cycle: Cycle,
+    buzz: ITossupAnswerEvent,
+    gameFormat: IGameFormat,
+    buzzIndex: number
+): JSX.Element {
     // TODO: Look into using something like shortid for the key
     return (
         <TossupAnswerCycleItem
             key={`buzz_${buzzIndex}_tu_${buzz.tossupIndex}_${buzz.marker.player.name}_${buzz.marker.player.teamName}`}
             cycle={cycle}
             buzz={buzz}
+            gameFormat={gameFormat}
         />
     );
 }
@@ -230,4 +237,5 @@ function createBonusProtestDetails(cycle: Cycle, protest: IBonusProtestEvent, pr
 
 interface ICycleItemListProps {
     cycle: Cycle;
+    gameFormat: IGameFormat;
 }

--- a/src/components/cycleItems/TossupAnswerCycleItem.tsx
+++ b/src/components/cycleItems/TossupAnswerCycleItem.tsx
@@ -4,20 +4,42 @@ import { observer } from "mobx-react-lite";
 import { Cycle } from "src/state/Cycle";
 import { ITossupAnswerEvent } from "src/state/Events";
 import { CycleItem } from "./CycleItem";
+import { IGameFormat } from "src/state/IGameFormat";
 
 export const TossupAnswerCycleItem = observer(
     (props: ITossupAnswerCycleItemProps): JSX.Element => {
         const deleteHandler = () => {
-            if (props.buzz.marker.correct) {
+            if (props.buzz.marker.points > 0) {
                 props.cycle.removeCorrectBuzz();
             } else {
                 props.cycle.removeWrongBuzz(props.buzz.marker.player);
             }
         };
 
-        const text = `${props.buzz.marker.player.name} (${props.buzz.marker.player.teamName}) answered ${
-            props.buzz.marker.correct ? "CORRECTLY" : "WRONGLY"
-        } on tossup #${props.buzz.tossupIndex + 1} at word ${props.buzz.marker.position + 1}`;
+        let buzzDescription = "answered";
+        const points: number = props.buzz.marker.points;
+        if (points === 0) {
+            buzzDescription = "answered WRONGLY";
+        } else if (points === props.gameFormat.negValue) {
+            buzzDescription = "NEGGED";
+        } else if (points === 10) {
+            buzzDescription = "answered CORRECTLY";
+        } else {
+            const powerIndex: number = props.gameFormat.pointsForPowers.indexOf(points);
+            // Add more "SUPER"s depending on the number of remaining power levels
+            // Subtract 1 since the first element is for regular powers
+            const superpowerLevel: number = props.gameFormat.pointsForPowers.length - powerIndex - 1;
+            if (superpowerLevel === 0) {
+                buzzDescription = "POWERED";
+            } else {
+                // Treat the 0 case as special since we don't want to create empty arrays for no reason
+                buzzDescription = new Array(superpowerLevel).fill("SUPER").join("") + "POWERED";
+            }
+        }
+
+        const text = `${props.buzz.marker.player.name} (${
+            props.buzz.marker.player.teamName
+        }) ${buzzDescription} on tossup #${props.buzz.tossupIndex + 1} at word ${props.buzz.marker.position + 1}`;
         return <CycleItem text={text} onDelete={deleteHandler} />;
     }
 );
@@ -25,4 +47,5 @@ export const TossupAnswerCycleItem = observer(
 export interface ITossupAnswerCycleItemProps {
     cycle: Cycle;
     buzz: ITossupAnswerEvent;
+    gameFormat: IGameFormat;
 }

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import {
+    Dialog,
+    DialogFooter,
+    PrimaryButton,
+    ContextualMenu,
+    DialogType,
+    IDialogContentProps,
+    IModalProps,
+    Label,
+    Link,
+    Stack,
+    StackItem,
+} from "@fluentui/react";
+import { AppState } from "src/state/AppState";
+
+declare const __BUILD_VERSION__: string;
+
+const content: IDialogContentProps = {
+    type: DialogType.normal,
+    title: "Help",
+    closeButtonAriaLabel: "Close",
+    showCloseButton: true,
+    styles: {
+        innerContent: {
+            display: "flex",
+            flexDirection: "column",
+        },
+    },
+};
+
+const modalProps: IModalProps = {
+    isBlocking: false,
+    dragOptions: {
+        moveMenuItemText: "Move",
+        closeMenuItemText: "Close",
+        menu: ContextualMenu,
+    },
+    styles: {
+        main: {
+            top: "25vh",
+        },
+    },
+    topOffsetFixed: true,
+};
+
+export const HelpDialog = observer(
+    (props: IHelpDialogPorps): JSX.Element => {
+        const closeHandler = React.useCallback(() => hideDialog(props), [props]);
+
+        return (
+            <Dialog
+                hidden={!props.appState.uiState.dialogState.helpDialogVisible}
+                dialogContentProps={content}
+                modalProps={modalProps}
+                maxWidth="30vw"
+                onDismiss={closeHandler}
+            >
+                <HelpDialogBody />
+                <DialogFooter>
+                    <PrimaryButton text="Close" onClick={closeHandler} />
+                </DialogFooter>
+            </Dialog>
+        );
+    }
+);
+
+const HelpDialogBody = observer(
+    (): JSX.Element => {
+        const version = `Version: ${__BUILD_VERSION__}`;
+
+        return (
+            <Stack>
+                <StackItem>
+                    <Label>{version}</Label>
+                </StackItem>
+                <StackItem>
+                    <Link href="https://github.com/alopezlago/MODAQ/wiki" target="_blank">
+                        How to use MODAQ
+                    </Link>
+                </StackItem>
+            </Stack>
+        );
+    }
+);
+
+function hideDialog(props: IHelpDialogPorps): void {
+    props.appState.uiState.dialogState.hideHelpDialog();
+}
+
+export interface IHelpDialogPorps {
+    appState: AppState;
+}

--- a/src/parser/FormattedTextParser.ts
+++ b/src/parser/FormattedTextParser.ts
@@ -7,19 +7,21 @@ export function parseFormattedText(text: string): IFormattedText[] {
         return result;
     }
 
+    let bolded = false;
     let emphasized = false;
     let required = false;
     let startIndex = 0;
 
     // If we need to support older browswers, use RegExp, exec, and a while loop. See
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
-    const matchIterator: IterableIterator<RegExpMatchArray> = text.matchAll(/<\/?em>|<\/?req>/gi);
+    const matchIterator: IterableIterator<RegExpMatchArray> = text.matchAll(/<\/?em>|<\/?req>|<\/?b>/gi);
 
     for (const match of matchIterator) {
         const slice: string = text.substring(startIndex, match.index);
         if (slice.length > 0) {
             const formattedSlice: IFormattedText = {
                 text: text.substring(startIndex, match.index),
+                bolded,
                 emphasized,
                 required,
             };
@@ -41,6 +43,12 @@ export function parseFormattedText(text: string): IFormattedText[] {
             case "</req>":
                 required = false;
                 break;
+            case "<b>":
+                bolded = true;
+                break;
+            case "</b>":
+                bolded = false;
+                break;
             default:
                 throw `Unknown match: ${tag}`;
         }
@@ -52,6 +60,7 @@ export function parseFormattedText(text: string): IFormattedText[] {
     if (startIndex < text.length) {
         result.push({
             text: text.substring(startIndex),
+            bolded,
             emphasized,
             required,
         });
@@ -91,6 +100,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
         } else {
             previousWord.push({
                 text: firstWord,
+                bolded: value.bolded,
                 emphasized: value.emphasized,
                 required: value.required,
             });
@@ -106,6 +116,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
             if (word.length > 0) {
                 const formattedWord: IFormattedText = {
                     text: word,
+                    bolded: value.bolded,
                     emphasized: value.emphasized,
                     required: value.required,
                 };
@@ -117,6 +128,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
         if (lastSegment.length > 0) {
             previousWord.push({
                 text: lastSegment,
+                bolded: value.bolded,
                 emphasized: value.emphasized,
                 required: value.required,
             });

--- a/src/parser/IFormattedText.ts
+++ b/src/parser/IFormattedText.ts
@@ -1,5 +1,6 @@
 export interface IFormattedText {
     text: string;
+    bolded: boolean;
     emphasized: boolean;
     required: boolean;
 }

--- a/src/sheets/LifsheetsGenerator.ts
+++ b/src/sheets/LifsheetsGenerator.ts
@@ -224,8 +224,7 @@ export const LifsheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: Calculate if this is a power or not
-                values: [[10]],
+                values: [[buzz.marker.points ?? 10]],
             },
         ];
     },

--- a/src/sheets/Sheets.ts
+++ b/src/sheets/Sheets.ts
@@ -21,6 +21,12 @@ import { UCSDSheetsGenerator } from "./UCSDSheetsGenerator";
 //         - Ones that use advanced stats would support phases that have advanced stats, and would allow us to jump to
 //           any phase.
 // - Create Format. Should include: power marker (e.g. (*)), neg value, power value, bouncebacks (when supported)
+//     - May be easier to support some basic things, like regulation tossup count. Could block Next -> if it's past that
+//         - Means we have to calculate how many TUs were read for the Sheets export
+//     - Could make Format something we only change in Options, but it should be part of the New Game flow. May require
+//       converting it to a wizard (add packet, add teams, choose format)
+//       - Format could also be a dropdown, with one option being "Custom..." that would open a popup. But we want to
+//         show what the format is too... could maybe do with collapsible panes.
 // Ideally, next steps would be to have a autorun or reaction when cycles change, so we can update the scoresheet.
 // But to keep things simple at first, can just export (adding players > 6 could cause problems, as could multiple tiebreakers)
 

--- a/src/sheets/TJSheetsGenerator.ts
+++ b/src/sheets/TJSheetsGenerator.ts
@@ -208,8 +208,7 @@ export const TJSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: Calculate if this is a power or not
-                values: [[10]],
+                values: [[buzz.marker.points ?? 10]],
             },
         ];
     },

--- a/src/sheets/UCSDSheetsGenerator.ts
+++ b/src/sheets/UCSDSheetsGenerator.ts
@@ -123,8 +123,7 @@ export const UCSDSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: Calculate if this is a power or not
-                values: [[10]],
+                values: [[buzz.marker.points ?? 10]],
             },
         ];
     },

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -9,6 +9,9 @@ export class DialogState {
     public exportToJsonDialogVisible: boolean;
 
     @ignore
+    public helpDialogVisible: boolean;
+
+    @ignore
     public importGameDialogVisible: boolean;
 
     @ignore
@@ -19,16 +22,21 @@ export class DialogState {
 
         this.editFormatDialogVisible = false;
         this.exportToJsonDialogVisible = false;
+        this.helpDialogVisible = false;
         this.importGameDialogVisible = false;
         this.newGameDialogVisible = false;
     }
 
-    public hideEditformatDialog(): void {
+    public hideEditFormatDialog(): void {
         this.editFormatDialogVisible = false;
     }
 
     public hideExportToJsonDialog(): void {
         this.exportToJsonDialogVisible = false;
+    }
+
+    public hideHelpDialog(): void {
+        this.helpDialogVisible = false;
     }
 
     public hideImportGameDialog(): void {
@@ -45,6 +53,10 @@ export class DialogState {
 
     public showExportToJsonDialog(): void {
         this.exportToJsonDialogVisible = true;
+    }
+
+    public showHelpDialog(): void {
+        this.helpDialogVisible = true;
     }
 
     public showImportGameDialog(): void {

--- a/src/state/GameFormats.ts
+++ b/src/state/GameFormats.ts
@@ -1,0 +1,64 @@
+import { IGameFormat } from "./IGameFormat";
+
+declare const __BUILD_VERSION__: string;
+
+export const ACFGameFormat: IGameFormat = {
+    bonusesBounceBack: false,
+    minimumOvertimeQuestionCount: 1,
+    overtimeIncludesBonuses: false,
+    negValue: -5,
+    pointsForPowers: [],
+    powerMarkers: [],
+    regulationTossupCount: 20,
+    timeoutsAllowed: 1,
+    version: __BUILD_VERSION__,
+};
+
+export const StandardPowersMACFGameFormat: IGameFormat = createMACFGameFormat([15], ["(*)"]);
+
+export const UndefinedGameFormat: IGameFormat = {
+    bonusesBounceBack: false,
+    minimumOvertimeQuestionCount: 1,
+    overtimeIncludesBonuses: false,
+    negValue: -5,
+    pointsForPowers: [15],
+    powerMarkers: ["(*)"],
+    regulationTossupCount: 99,
+    timeoutsAllowed: 99,
+    version: __BUILD_VERSION__,
+};
+
+export function createMACFGameFormat(pointsForPowers: number[], powerMarkers: string[]): IGameFormat {
+    return {
+        ...ACFGameFormat,
+        pointsForPowers,
+        powerMarkers,
+    };
+}
+
+export function getUpgradedFormatVersion(format: IGameFormat): IGameFormat {
+    if (format.version === __BUILD_VERSION__) {
+        return format;
+    }
+
+    // We need to compare the fields between the given format and the current format, so we need to iterate over them.
+    // This requires using the array/dictionary syntax for accessing fields, which requires using any.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const defaultFormat: any = UndefinedGameFormat as any;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formatObject: any = format as any;
+    for (const key of Object.keys(defaultFormat)) {
+        if (formatObject[key] == undefined) {
+            throw new Error(
+                `Game format uses an incompatible version (${format.version}). Unknown setting "${key}". Export your game and see if you can update your format manually, or reset your game`
+            );
+        } else if (typeof formatObject[key] !== typeof defaultFormat[key]) {
+            throw new Error(
+                `Game format uses an incompatible version (${format.version}). "${key}" is an incompatible type. Export your game and see if you can update your format manually, or reset your game`
+            );
+        }
+    }
+
+    return format;
+}

--- a/src/state/IBuzzMarker.ts
+++ b/src/state/IBuzzMarker.ts
@@ -2,6 +2,6 @@ import { IPlayer } from "./TeamState";
 
 export interface IBuzzMarker {
     position: number;
-    correct: boolean;
     player: IPlayer;
+    points: number;
 }

--- a/src/state/IGameFormat.ts
+++ b/src/state/IGameFormat.ts
@@ -1,0 +1,21 @@
+// This should closely mirror ScoringRules here https://github.com/quizbowl/schema/blob/master/schema/tournament.graphql,
+// since it covers much of the same ground
+// We may need to add additional rules, though, such as if powers are supported
+
+export interface IGameFormat {
+    regulationTossupCount: number;
+    minimumOvertimeQuestionCount: number;
+    overtimeIncludesBonuses: boolean;
+    bonusesBounceBack: boolean;
+    negValue: number;
+
+    // Empty array means that powers aren't supported
+    // This array must be in descending order
+    pointsForPowers: number[];
+    powerMarkers: string[];
+
+    timeoutsAllowed: number;
+
+    // Tells us which version this format was generated from, so we can support backwards compatibility if possible
+    version: string;
+}

--- a/src/state/PacketState.ts
+++ b/src/state/PacketState.ts
@@ -1,6 +1,17 @@
 import { observable, makeObservable, makeAutoObservable } from "mobx";
+import { format } from "mobx-sync";
+
+import * as FormattedTextParser from "src/parser/FormattedTextParser";
+import { IFormattedText } from "src/parser/IFormattedText";
+import { IGameFormat } from "./IGameFormat";
 
 export class PacketState {
+    // Anything with methods/computeds not at the top level needs to use @format to deserialize correctly
+    @format((deserializedArray: IQuestion[]) => {
+        return deserializedArray.map((deserializedTossup) => {
+            return new Tossup(deserializedTossup.question, deserializedTossup.answer);
+        });
+    })
     public tossups: Tossup[];
 
     public bonuses: Bonus[];
@@ -43,8 +54,63 @@ export class Tossup implements IQuestion {
     public answer: string;
 
     constructor(question: string, answer: string) {
+        makeAutoObservable(this);
+
         this.question = question;
         this.answer = answer;
+    }
+
+    public get formattedQuestionText(): IFormattedText[][] {
+        // Include the ■ to give an end of question marker
+        return FormattedTextParser.splitFormattedTextIntoWords(this.question).concat([
+            [{ text: "■", bolded: false, emphasized: false, required: false }],
+        ]);
+    }
+
+    public getPointsAtPosition(format: IGameFormat, wordIndex: number): number {
+        // If there's no powers, default to 10 points
+        if (format.powerMarkers.length === 0) {
+            return 10;
+        }
+
+        const formattedQuestionText: IFormattedText[][] = this.formattedQuestionText;
+
+        const words: string[] = formattedQuestionText.map((questionText) =>
+            questionText.reduce((result, text) => result + text.text, "").trim()
+        );
+
+        // Ignore the last word, which is an end of question marker
+        const lastWordIndex: number = words.length - 1;
+
+        // Go through each power value, and see if it appears in the question text. If it does, and the buzz is before
+        // that point, give them that power.
+        // One potential optimization would be to remove all the words up to that index if we find it, so we have to
+        // look through less words
+        let powerMarkersFound = 0;
+        for (let i = 0; i < format.powerMarkers.length; i++) {
+            const powerMarker: string = format.powerMarkers[i];
+            const powerMarkerIndex: number = words.indexOf(powerMarker);
+
+            // TODO: When we skip over pronunication guides, we'll need to calculate how many words they take up, so
+            // we can correctly see if the buzz is in power
+            // For a tossup a b (+) c (*) d
+            // If the buzz is at position 1 (b), 1 < 2 - 0, so we'll get the superpower
+            // If the buzz is at position 2 (c), 2 < 2 will fail. The next marker is at index 4, and 2 < 4 - 1 => 2 < 3,
+            // so they will get the power.
+            // If the buzz is at position 3, though (d), 3 < 4 - 1= > 3 < 3 is false, so they will get the default value
+            if (powerMarkerIndex >= 0) {
+                // We only want to correct the index for the power markers found. Some questions may not have
+                // superpowers, so don't count them if we didn't find them.
+                if (powerMarkerIndex !== lastWordIndex && wordIndex <= powerMarkerIndex - (powerMarkersFound + 1)) {
+                    return format.pointsForPowers[i];
+                }
+
+                powerMarkersFound++;
+            }
+        }
+
+        // Not in power, so return the default value
+        return 10;
     }
 }
 

--- a/tests/CycleTests.ts
+++ b/tests/CycleTests.ts
@@ -11,7 +11,7 @@ describe("CycleTests", () => {
             const marker: IBuzzMarker = {
                 player: new Player("Alice", "Alpha", /* isStarter */ true),
                 position: 10,
-                correct: true,
+                points: 10,
             };
             cycle.addCorrectBuzz(marker, 2, 1);
 

--- a/tests/FormattedTextParserTests.ts
+++ b/tests/FormattedTextParserTests.ts
@@ -11,6 +11,7 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text,
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
@@ -23,6 +24,7 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text: expectedText,
+                    bolded: false,
                     emphasized: true,
                     required: false,
                 },
@@ -35,6 +37,7 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text: expectedText,
+                    bolded: false,
                     emphasized: false,
                     required: true,
                 },
@@ -46,26 +49,31 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text: "Before ",
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
                 {
                     text: "emphasized then",
+                    bolded: false,
                     emphasized: true,
                     required: false,
                 },
                 {
                     text: " in between ",
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
                 {
                     text: "required then",
+                    bolded: false,
                     emphasized: false,
                     required: true,
                 },
                 {
                     text: " done.",
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
@@ -77,21 +85,25 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text: "The epic ",
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
                 {
                     text: "The ",
+                    bolded: false,
                     emphasized: true,
                     required: false,
                 },
                 {
                     text: "Iliad",
+                    bolded: false,
                     emphasized: true,
                     required: true,
                 },
                 {
                     text: " is by Homer",
+                    bolded: false,
                     emphasized: false,
                     required: false,
                 },
@@ -106,6 +118,24 @@ describe("FormattedTextParserTests", () => {
                 return [
                     {
                         text: word,
+                        bolded: false,
+                        emphasized: false,
+                        required: false,
+                    },
+                ];
+            });
+
+            expect(result).to.deep.equal(expected);
+        });
+        it("All bolded", () => {
+            const expectedText = "This text is all bolded.";
+            const textToFormat = `<b>${expectedText}</b>`;
+            const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(textToFormat);
+            const expected: IFormattedText[][] = expectedText.split(/\s+/g).map((word) => {
+                return [
+                    {
+                        text: word,
+                        bolded: true,
                         emphasized: false,
                         required: false,
                     },
@@ -122,6 +152,7 @@ describe("FormattedTextParserTests", () => {
                 return [
                     {
                         text: word,
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
@@ -138,6 +169,7 @@ describe("FormattedTextParserTests", () => {
                 return [
                     {
                         text: word,
+                        bolded: false,
                         emphasized: false,
                         required: true,
                     },
@@ -153,6 +185,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "Before",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -160,6 +193,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "emphasized",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
@@ -167,6 +201,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "then",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
@@ -174,6 +209,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "in",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -181,6 +217,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "between",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -188,6 +225,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "required",
+                        bolded: false,
                         emphasized: false,
                         required: true,
                     },
@@ -195,6 +233,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "then",
+                        bolded: false,
                         emphasized: false,
                         required: true,
                     },
@@ -202,6 +241,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "done.",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -215,6 +255,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "The",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -222,6 +263,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "epic",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -229,6 +271,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "The",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
@@ -236,6 +279,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "Iliad",
+                        bolded: false,
                         emphasized: true,
                         required: true,
                     },
@@ -243,6 +287,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "is",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -250,6 +295,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "by",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -257,6 +303,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "Homer",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -270,6 +317,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "My",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -277,6 +325,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "book",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
@@ -284,11 +333,13 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "title",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
                     {
                         text: ",",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -296,6 +347,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "written",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -303,6 +355,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "by",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -310,6 +363,7 @@ describe("FormattedTextParserTests", () => {
                 [
                     {
                         text: "me.",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
@@ -317,32 +371,43 @@ describe("FormattedTextParserTests", () => {
             ]);
         });
         it("One word with formatting", () => {
-            const text = "Plain<req>required</req>dull<em>emphasized</em>boring";
+            const text = "Plain<req>required</req>dull<em>emphasized</em><b>bolded</b>boring";
             const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(text);
             expect(result).to.deep.equal([
                 [
                     {
                         text: "Plain",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
                     {
                         text: "required",
+                        bolded: false,
                         emphasized: false,
                         required: true,
                     },
                     {
                         text: "dull",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },
                     {
                         text: "emphasized",
+                        bolded: false,
                         emphasized: true,
                         required: false,
                     },
                     {
+                        text: "bolded",
+                        bolded: true,
+                        emphasized: false,
+                        required: false,
+                    },
+                    {
                         text: "boring",
+                        bolded: false,
                         emphasized: false,
                         required: false,
                     },

--- a/tests/GameFormatTests.ts
+++ b/tests/GameFormatTests.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+
+import * as GameFormats from "src/state/GameFormats";
+import { IGameFormat } from "src/state/IGameFormat";
+
+describe("GameFormatTests", () => {
+    describe("getUpgradedFormatVersion", () => {
+        // Most of these tests are handled by FormattedTextParserTests, so just test that it's hooked up to it and that
+        // we include the end character
+        it("Current version succeeds, no changes", () => {
+            const upgradedFormat: IGameFormat = GameFormats.getUpgradedFormatVersion(GameFormats.UndefinedGameFormat);
+            expect(upgradedFormat).to.equal(GameFormats.UndefinedGameFormat);
+        });
+        it("Unknown version with same fields succeeds", () => {
+            const gameFormat: IGameFormat = { ...GameFormats.UndefinedGameFormat, version: "unknown" };
+
+            const upgradedFormat: IGameFormat = GameFormats.getUpgradedFormatVersion(gameFormat);
+
+            // Change the version back
+            upgradedFormat.version = GameFormats.UndefinedGameFormat.version;
+            expect(upgradedFormat).to.deep.equal(GameFormats.UndefinedGameFormat);
+        });
+        it("Unknown version with same fields, different values succeeds", () => {
+            const gameFormat: IGameFormat = { ...GameFormats.ACFGameFormat, version: "unknown" };
+
+            const upgradedFormat: IGameFormat = GameFormats.getUpgradedFormatVersion(gameFormat);
+
+            // Change the version back
+            upgradedFormat.version = GameFormats.UndefinedGameFormat.version;
+            expect(upgradedFormat).to.deep.equal(GameFormats.ACFGameFormat);
+        });
+        it("Unknown version with undefined field throws error", () => {
+            const gameFormat: IGameFormat = {
+                ...GameFormats.UndefinedGameFormat,
+                version: "unknown",
+            };
+
+            (gameFormat as IGameFormat | { negValue: number | undefined }).negValue = undefined;
+            expect(() => GameFormats.getUpgradedFormatVersion(gameFormat)).to.throw;
+        });
+        it("Unknown version with different type throws error", () => {
+            const gameFormat: IGameFormat = {
+                ...GameFormats.UndefinedGameFormat,
+                version: "unknown",
+            };
+
+            (gameFormat as IGameFormat | { negValue: string | undefined }).negValue = "-5";
+            expect(() => GameFormats.getUpgradedFormatVersion(gameFormat)).to.throw;
+        });
+    });
+});

--- a/tests/GetBonusIndexTests.ts
+++ b/tests/GetBonusIndexTests.ts
@@ -37,9 +37,9 @@ describe("GameStateTests", () => {
             const buzzCycleIndex = 1;
             game.cycles[buzzCycleIndex].addNeg(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: -5,
                 },
                 0
             );
@@ -54,9 +54,9 @@ describe("GameStateTests", () => {
             const buzzCycleIndex = 1;
             game.cycles[buzzCycleIndex].addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: 10,
                 },
                 0,
                 0
@@ -72,9 +72,9 @@ describe("GameStateTests", () => {
             const buzzCycleIndex = 1;
             game.cycles[buzzCycleIndex].addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: 10,
                 },
                 0,
                 0
@@ -92,9 +92,9 @@ describe("GameStateTests", () => {
             const cycle: Cycle = game.cycles[buzzCycleIndex];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: 10,
                 },
                 0,
                 0
@@ -113,9 +113,9 @@ describe("GameStateTests", () => {
             const secondBuzzCycleIndex = 1;
             game.cycles[buzzCycleIndex].addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: 10,
                 },
                 0,
                 0
@@ -123,9 +123,9 @@ describe("GameStateTests", () => {
 
             game.cycles[secondBuzzCycleIndex].addCorrectBuzz(
                 {
-                    correct: true,
                     player: secondTeamPlayer,
                     position: 2,
+                    points: 10,
                 },
                 1,
                 1
@@ -142,9 +142,9 @@ describe("GameStateTests", () => {
             const buzzCycle: Cycle = game.cycles[buzzCycleIndex];
             buzzCycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 1,
+                    points: 10,
                 },
                 0,
                 0
@@ -160,9 +160,9 @@ describe("GameStateTests", () => {
             const nextBuzzCycle: Cycle = game.cycles[nextBuzzCycleIndex];
             nextBuzzCycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: 2,
+                    points: 10,
                 },
                 1,
                 game.packet.bonuses.length - 1

--- a/tests/NewGameValidatorTests.ts
+++ b/tests/NewGameValidatorTests.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import * as NewGameValidator from "src/state/NewGameValidator";
 import { IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
 import { Player } from "src/state/TeamState";
-import { PacketState } from "src/state/PacketState";
+import { PacketState, Tossup } from "src/state/PacketState";
 import { Cycle } from "src/state/Cycle";
 
 describe("NewGameValidatorTests", () => {
@@ -66,12 +66,7 @@ describe("NewGameValidatorTests", () => {
     });
     describe("isValid", () => {
         const defaultPacket: PacketState = new PacketState();
-        defaultPacket.setTossups([
-            {
-                question: "Test question",
-                answer: "answer",
-            },
-        ]);
+        defaultPacket.setTossups([new Tossup("Test question", "answer")]);
 
         it("No players in first team", () => {
             assertNewGameIsInvalid({

--- a/tests/PacketStateTossupTests.ts
+++ b/tests/PacketStateTossupTests.ts
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+
+import * as GameFormats from "src/state/GameFormats";
+import { Tossup } from "src/state/PacketState";
+import { IFormattedText } from "src/parser/IFormattedText";
+import { IGameFormat } from "src/state/IGameFormat";
+
+const noPowersGameFormat: IGameFormat = { ...GameFormats.UndefinedGameFormat, powerMarkers: [], pointsForPowers: [] };
+const powersGameFormat: IGameFormat = {
+    ...GameFormats.UndefinedGameFormat,
+    powerMarkers: ["(*)"],
+    pointsForPowers: [15],
+};
+const superpowersGameFormat: IGameFormat = {
+    ...GameFormats.UndefinedGameFormat,
+    powerMarkers: ["(+)", "(*)"],
+    pointsForPowers: [20, 15],
+};
+
+describe("PacketStateTossupTests", () => {
+    describe("formattedQuestionText", () => {
+        // Most of these tests are handled by FormattedTextParserTests, so just test that it's hooked up to it and that
+        // we include the end character
+        it("formattedQuestionText has end marker", () => {
+            const tossup: Tossup = new Tossup("This is my question", "Answer");
+            const formattedText: IFormattedText[][] = tossup.formattedQuestionText;
+            expect(formattedText.length).to.equal(5);
+            expect(formattedText[0].length).to.equal(1);
+            expect(formattedText[0][0].text).to.equal("This");
+            expect(formattedText[4].length).to.equal(1);
+            expect(formattedText[4][0].text).to.equal("■");
+        });
+        it("formattedQuestionText has formatting", () => {
+            const tossup: Tossup = new Tossup("<b>This is</b> my question", "Answer");
+            const formattedText: IFormattedText[][] = tossup.formattedQuestionText;
+            expect(formattedText.length).to.be.greaterThan(1);
+            expect(formattedText[0].length).to.equal(1);
+
+            const formattedWord: IFormattedText = formattedText[0][0];
+            expect(formattedWord.text).to.equal("This");
+            expect(formattedWord.bolded).to.be.true;
+            expect(formattedWord.emphasized).to.be.false;
+            expect(formattedWord.required).to.be.false;
+        });
+    });
+
+    describe("getPointsAtPosition", () => {
+        it("No powers", () => {
+            const tossup: Tossup = new Tossup("This is my question", "Answer");
+            const points: number = tossup.getPointsAtPosition(noPowersGameFormat, 2);
+            expect(points).to.equal(10);
+        });
+        it("Negative value", () => {
+            const tossup: Tossup = new Tossup("This is my question", "Answer");
+            const points: number = tossup.getPointsAtPosition(noPowersGameFormat, -1);
+
+            // Go with the default if we get a nonsense value
+            expect(points).to.equal(10);
+        });
+        it("At last word", () => {
+            const tossup: Tossup = new Tossup("This is my question", "Answer");
+            const points: number = tossup.getPointsAtPosition(noPowersGameFormat, tossup.question.length - 1);
+            expect(points).to.equal(10);
+        });
+        it("At end", () => {
+            const tossup: Tossup = new Tossup("This is my question", "Answer");
+            const points: number = tossup.getPointsAtPosition(noPowersGameFormat, tossup.question.length);
+            expect(points).to.equal(10);
+        });
+        it("In power", () => {
+            const tossup: Tossup = new Tossup("This is my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(powersGameFormat, 2);
+            expect(points).to.equal(15);
+        });
+        it("Out of power", () => {
+            const tossup: Tossup = new Tossup("This is my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(powersGameFormat, 3);
+            expect(points).to.equal(10);
+        });
+        it("In superpower", () => {
+            const tossup: Tossup = new Tossup("This is (+) my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(superpowersGameFormat, 1);
+            expect(points).to.equal(20);
+        });
+        it("In power but not superpower", () => {
+            const tossup: Tossup = new Tossup("This is (+) my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(superpowersGameFormat, 2);
+            expect(points).to.equal(15);
+        });
+        it("Out of power and superpower", () => {
+            const tossup: Tossup = new Tossup("This is (+) my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(superpowersGameFormat, 3);
+            expect(points).to.equal(10);
+        });
+        it("In power with power at last word", () => {
+            const tossup: Tossup = new Tossup("This is my question (*)", "Answer");
+            const points: number = tossup.getPointsAtPosition(powersGameFormat, 3);
+            expect(points).to.equal(15);
+        });
+        it("In superpower with superpower at last word", () => {
+            const tossup: Tossup = new Tossup("This is my question (+)", "Answer");
+            const points: number = tossup.getPointsAtPosition(superpowersGameFormat, 3);
+            expect(points).to.equal(20);
+        });
+        it("In power with no superpower in question", () => {
+            const tossup: Tossup = new Tossup("This is my (*) question", "Answer");
+            const points: number = tossup.getPointsAtPosition(superpowersGameFormat, 2);
+            expect(points).to.equal(15);
+        });
+    });
+});

--- a/tests/SheetsTests.ts
+++ b/tests/SheetsTests.ts
@@ -187,9 +187,9 @@ describe("SheetsTests", () => {
             const position = 1;
             appState.game.cycles[0].addNeg(
                 {
-                    correct: false,
                     player,
                     position,
+                    points: -5,
                 },
                 0
             );
@@ -220,9 +220,9 @@ describe("SheetsTests", () => {
             const position = 1;
             appState.game.cycles[0].addNeg(
                 {
-                    correct: false,
                     player,
                     position,
+                    points: -5,
                 },
                 0
             );
@@ -253,9 +253,9 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 0,
                 0
@@ -303,9 +303,9 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 0,
                 0
@@ -343,6 +343,56 @@ describe("SheetsTests", () => {
             });
         });
 
+        const playerPowersTest = async (
+            sheetType: SheetType,
+            verifyCells: (ranges: gapi.client.sheets.ValueRange[], position: number) => void
+        ): Promise<void> => {
+            const appState: AppState = createAppStateForExport(sheetType);
+
+            const player: Player = findPlayerOnTeam(appState, "Alpha");
+            const position = 2;
+            const cycle: Cycle = appState.game.cycles[0];
+            cycle.addCorrectBuzz(
+                {
+                    player,
+                    position,
+                    points: 15,
+                },
+                0,
+                0
+            );
+            cycle.setBonusPartAnswer(0, true, 10);
+            cycle.setBonusPartAnswer(1, true, 10);
+            cycle.setBonusPartAnswer(2, false, 0);
+
+            await verifyExportToSheetSuccess(appState, (ranges) => verifyCells(ranges, position));
+        };
+        it("First team player powers written to sheet (Lifsheets)", async () => {
+            await playerPowersTest(SheetType.Lifsheets, (ranges, position) => {
+                verifyCell(ranges, "B8", 15);
+                verifyCell(ranges, "AJ8", position);
+
+                // Verify bonus
+                verifyCell(ranges, "H8", "110");
+            });
+        });
+        it("First team player powers written to sheet (TJSheets)", async () => {
+            await playerPowersTest(SheetType.TJSheets, (ranges) => {
+                verifyCell(ranges, "C4", 15);
+
+                // Verify bonus
+                verifyCell(ranges, "I4", 20);
+            });
+        });
+        it("First team player powers written to sheet (UCSDSheets)", async () => {
+            await playerPowersTest(SheetType.UCSDSheets, (ranges) => {
+                verifyCell(ranges, "C4", 15);
+
+                // Verify bonus
+                verifyUCSDBonusCells(ranges, "I4:K4", [true, true, false]);
+            });
+        });
+
         const twoBuzzesInSameCycleTest = async (
             sheetType: SheetType,
             verifyCells: (ranges: gapi.client.sheets.ValueRange[], negPosition: number, correctPosition: number) => void
@@ -357,17 +407,17 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addNeg(
                 {
-                    correct: false,
                     player: secondTeamPlayer,
                     position: negPosition,
+                    points: -5,
                 },
                 0
             );
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player: firstTeamPlayer,
                     position: correctPosition,
+                    points: 10,
                 },
                 0,
                 0
@@ -416,9 +466,9 @@ describe("SheetsTests", () => {
             const position = 1;
             appState.game.cycles[0].addNeg(
                 {
-                    correct: false,
                     player,
                     position,
+                    points: -5,
                 },
                 0
             );
@@ -438,9 +488,9 @@ describe("SheetsTests", () => {
             const position = 1;
             appState.game.cycles[0].addNeg(
                 {
-                    correct: false,
                     player,
                     position,
+                    points: 10,
                 },
                 0
             );
@@ -461,9 +511,9 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 0,
                 0
@@ -490,9 +540,9 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 0,
                 0
@@ -519,9 +569,9 @@ describe("SheetsTests", () => {
             const cycle: Cycle = appState.game.cycles[0];
             cycle.addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 0,
                 0
@@ -795,9 +845,9 @@ describe("SheetsTests", () => {
             const position = 3;
             appState.game.cycles[tossupsScored - 1].addCorrectBuzz(
                 {
-                    correct: true,
                     player,
                     position,
+                    points: 10,
                 },
                 20,
                 0

--- a/tests/TestInit.js
+++ b/tests/TestInit.js
@@ -1,0 +1,6 @@
+// Build variables defined in webpack have to be defined here, unless we want to test the webpack bundle explicitly
+// Otherwise, tests fail because these globals won't be defined
+
+global.__BUILD_VERSION__ = "Test";
+global.__GOOGLE_CLIENT_ID__ = "1";
+global.__YAPP_SERVICE__ = "https://localhost/api/ParseDocx";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,8 @@ const devEntries = [
     "./src/index",
 ];
 const prodEntries = ["./src/index"];
+const dateString = new Date().toISOString();
+const version = dateString.substring(0, dateString.indexOf("T"));
 
 // TODO: Use the Define plugin to setup variables like the Google Sheets app client ID, etc. from the file system or
 // from env variables. See https://webpack.js.org/plugins/define-plugin/
@@ -62,7 +64,9 @@ module.exports = (env, argv) => {
                     files: "./src/**/*.{ts,tsx,js,jsx}",
                 },
             }),
+            // Update Tests\TestInit.js to include values for these constants
             new webpack.DefinePlugin({
+                __BUILD_VERSION__: JSON.stringify(`${isProduction ? "" : "dev_"}${version}`),
                 // If you want a different Google Sheets ID, replace this with your own
                 __GOOGLE_CLIENT_ID__: JSON.stringify(
                     "1038902414768-nj056sbrbe0oshavft2uq9et6tvbu2d5.apps.googleusercontent.com"


### PR DESCRIPTION
- Add support for powers
  - Clicking on power markers no longer brings up the menu
  - Power markers are not counted toward the buzz position
  - Only (*) and 15-point powers currently supported
- Add help dialog
  - Add a version to see which build of MODAQ someone is using
- Show more specific descriptions for buzzes in the event viewer
- Add game formats under the hood. Currently non-configurable