### PR TITLE
Merged PR 191: Add dropdown for format in new games + Use Text instea…

### DIFF
--- a/src/components/BonusQuestionPart.tsx
+++ b/src/components/BonusQuestionPart.tsx
@@ -19,6 +19,7 @@ export const BonusQuestionPart = observer((props: IBonusQuestionPartProps) => {
 
     const bonusPartText: IFormattedText[] = FormattedTextParser.parseFormattedText(props.bonusPart.question);
 
+    // TODO: We should try to resize the checkbox's box to match the font size
     return (
         <div className="bonus-part">
             <div className={classes.bonusPartQuestionText}>
@@ -65,7 +66,7 @@ interface IBonusQuestionPartClassNames {
 const getClassNames = (disabled: boolean): IBonusQuestionPartClassNames =>
     mergeStyleSets({
         bonusPartQuestionText: [
-            { display: "flex", marginTop: 5 },
+            { display: "flex", marginTop: "1em" },
             disabled && {
                 color: "#888888",
             },
@@ -77,5 +78,6 @@ const getClassNames = (disabled: boolean): IBonusQuestionPartClassNames =>
         ],
         bonusPartAnswerSpacer: {
             padding: "0 24px",
+            margin: "0.25em 0 1em 0",
         },
     });

--- a/src/components/CycleChooser.tsx
+++ b/src/components/CycleChooser.tsx
@@ -59,14 +59,11 @@ export const CycleChooser = observer((props: ICycleChooserProps) => {
             &larr; Previous
         </DefaultButton>
     );
+
+    const nextButtonText: string = shouldNextButtonExport(props) ? "Export..." : "Next →";
     const nextButton: JSX.Element = (
-        <DefaultButton
-            key="nextButton"
-            onClick={onNextClickHandler}
-            disabled={nextDisabled(props)}
-            styles={nextButtonStyle}
-        >
-            Next &rarr;
+        <DefaultButton key="nextButton" onClick={onNextClickHandler} styles={nextButtonStyle}>
+            {nextButtonText}
         </DefaultButton>
     );
 
@@ -101,13 +98,9 @@ export const CycleChooser = observer((props: ICycleChooserProps) => {
     );
 });
 
-// We may want these to be computed properties in the UIState, but that requires it having access to the packet
-function nextDisabled(props: ICycleChooserProps): boolean {
+function shouldNextButtonExport(props: ICycleChooserProps): boolean {
     const nextCycleIndex: number = props.appState.uiState.cycleIndex + 1;
-    return (
-        nextCycleIndex >= props.appState.game.packet.tossups.length ||
-        nextCycleIndex >= props.appState.game.playableCycles.length
-    );
+    return nextCycleIndex >= props.appState.game.playableCycles.length;
 }
 
 function onProposedQuestionNumberBlur(event: React.FocusEvent<HTMLInputElement>, props: ICycleChooserProps): void {
@@ -124,7 +117,16 @@ function onProposedQuestionNumberKeyDown(
 }
 
 function onNextClick(props: ICycleChooserProps): void {
-    props.appState.uiState.nextCycle();
+    if (shouldNextButtonExport(props)) {
+        // If they use Sheets, show the Export Sheets dialog. Otherwise, show the Export JSON dialog
+        if (props.appState.uiState.sheetsState.sheetId != undefined) {
+            props.appState.uiState.createPendingSheet();
+        } else {
+            props.appState.uiState.dialogState.showExportToJsonDialog();
+        }
+    } else {
+        props.appState.uiState.nextCycle();
+    }
 }
 
 function onPreviousClick(props: ICycleChooserProps): void {

--- a/src/components/EventViewer.tsx
+++ b/src/components/EventViewer.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import { DetailsList, CheckboxVisibility, SelectionMode, IColumn } from "@fluentui/react/lib/DetailsList";
-import { Label } from "@fluentui/react/lib/Label";
+import { DetailsList, CheckboxVisibility, SelectionMode, IColumn, Label, Text } from "@fluentui/react";
 import { mergeStyleSets } from "@fluentui/react";
 
 import { CycleItemList } from "./cycleItems/CycleItemList";
@@ -91,7 +90,7 @@ function onRenderItemColumn(item: Cycle, gameFormat: IGameFormat, index: number,
             return (
                 <>
                     <CycleItemList cycle={item} gameFormat={gameFormat} />
-                    <Label>{`(${scoreInCurrentCycle[0]} - ${scoreInCurrentCycle[1]})`}</Label>
+                    <Text>{`(${scoreInCurrentCycle[0]} - ${scoreInCurrentCycle[1]})`}</Text>
                 </>
             );
         default:
@@ -116,7 +115,7 @@ const getClassNames = (): IEventViewerClassNames =>
     mergeStyleSets({
         eventViewerContainer: {
             border: "1px black solid",
-            maxHeight: "80vh",
+            maxHeight: "90vh",
             overflowY: "auto",
         },
     });

--- a/src/components/GameFormatPicker.tsx
+++ b/src/components/GameFormatPicker.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { observer } from "mobx-react-lite";
+import { Dropdown, IDropdownOption, IDropdownStyles, Stack, StackItem, Text } from "@fluentui/react";
+
+import * as GameFormats from "src/state/GameFormats";
+import { AppState } from "src/state/AppState";
+
+const dropdownStyles: Partial<IDropdownStyles> = {
+    root: {
+        width: "20vw",
+    },
+};
+
+export const GameFormatPicker = observer((props: IGameFormatPickerProps) => {
+    const changeHandler = React.useCallback(
+        (ev: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+            if (option?.data != undefined) {
+                props.appState.uiState.setPendingNewGameFormat(option.data);
+            }
+        },
+        [props]
+    );
+
+    if (props.appState.uiState.pendingNewGame == undefined) {
+        return null;
+    }
+
+    const options: IDropdownOption[] = GameFormats.getKnownFormats().map((format) => {
+        return {
+            key: format.displayName,
+            text: format.displayName,
+            data: format,
+            selected: props.appState.uiState.pendingNewGame?.gameFormat.displayName === format.displayName,
+        };
+    });
+
+    return (
+        <Stack horizontal={true}>
+            <StackItem>
+                <Dropdown label="Format" options={options} onChange={changeHandler} styles={dropdownStyles} />
+            </StackItem>
+            <StackItem>
+                <ul>
+                    <li>
+                        <Text>{`Tossups in regulation: ${props.appState.uiState.pendingNewGame.gameFormat.regulationTossupCount}`}</Text>
+                    </li>
+                    <li>
+                        <Text>{`Neg value: ${props.appState.uiState.pendingNewGame.gameFormat.negValue}`}</Text>
+                    </li>
+                    <li>
+                        <Text>{`Has powers: ${
+                            props.appState.uiState.pendingNewGame.gameFormat.powerMarkers.length > 0 ? "Yes" : "No"
+                        }`}</Text>
+                    </li>
+                </ul>
+            </StackItem>
+        </Stack>
+    );
+});
+
+export interface IGameFormatPickerProps {
+    appState: AppState;
+}

--- a/src/components/GameViewer.tsx
+++ b/src/components/GameViewer.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { mergeStyleSets } from "@fluentui/react";
+import { IStackTokens, mergeStyleSets, Stack, StackItem } from "@fluentui/react";
 
 import { QuestionViewerContainer } from "./QuestionViewerContainer";
 import { Scoreboard } from "./Scoreboard";
 import { EventViewer } from "./EventViewer";
 import { GameBar } from "./GameBar";
 import { AppState } from "src/state/AppState";
+
+const scoreboardAndQuestionViewerTokens: IStackTokens = { childrenGap: 20 };
 
 // TODO: Figure out CSS to prevent the content from growing too much. GameViewer should probably have like 90/100% of
 // the height. We need to make sure the contents also don't grow beyond the page, and add overflow handling to the
@@ -15,19 +17,29 @@ export const GameViewer = observer((props: IGameViewerProps) => {
     const gameExists: boolean = props.appState.game.isLoaded;
     const classes: IGameViewerClassNames = getClassNames(gameExists);
 
+    // TODO: See if we should convert the game viewer section into a StackItem. It's using a grid now, so it might
+    // not make sense to have it be a stack item. Alternatively, we could make another Stack that's horizontally aligned
     return (
-        <div>
-            <GameBar appState={props.appState} />
+        <Stack>
+            <StackItem>
+                <GameBar appState={props.appState} />
+            </StackItem>
             <div className={classes.gameViewer}>
-                <div className={classes.questionViewerContainer}>
-                    <QuestionViewerContainer appState={props.appState}></QuestionViewerContainer>
-                </div>
-                <div className={classes.scoreboardContainer}>
+                <StackItem className={classes.questionViewerContainer}>
+                    <Stack tokens={scoreboardAndQuestionViewerTokens}>
+                        <StackItem>
+                            <Scoreboard appState={props.appState} />
+                        </StackItem>
+                        <StackItem>
+                            <QuestionViewerContainer appState={props.appState}></QuestionViewerContainer>
+                        </StackItem>
+                    </Stack>
+                </StackItem>
+                <StackItem className={classes.eventViewerContainer}>
                     <EventViewer appState={props.appState} />
-                    <Scoreboard appState={props.appState} />
-                </div>
+                </StackItem>
             </div>
-        </div>
+        </Stack>
     );
 });
 
@@ -37,7 +49,7 @@ export interface IGameViewerProps {
 
 interface IGameViewerClassNames {
     gameViewer: string;
-    scoreboardContainer: string;
+    eventViewerContainer: string;
     questionViewerContainer: string;
 }
 
@@ -50,7 +62,7 @@ const getClassNames = (gameLoaded: boolean): IGameViewerClassNames =>
             gridTemplateColumns: "3fr 1fr",
             // height: "100%",
         },
-        scoreboardContainer: {
+        eventViewerContainer: {
             margin: "0 10px",
             overflowY: "auto",
             visibility: gameLoaded ? undefined : "hidden",

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { mergeStyleSets } from "@fluentui/react";
-
+import { Label, mergeStyleSets } from "@fluentui/react";
 import { observer } from "mobx-react-lite";
+
 import { AppState } from "src/state/AppState";
 
 export const Scoreboard = observer((props: IScoreboardProps) => {
@@ -10,7 +10,7 @@ export const Scoreboard = observer((props: IScoreboardProps) => {
     const scores: [number, number] = props.appState.game.finalScore;
     const teamNames = props.appState.game.teamNames;
     const result = teamNames.length >= 2 ? `${teamNames[0]}: ${scores[0]}, ${teamNames[1]}: ${scores[1]}` : "";
-    return <div className={classes.board}>{result}</div>;
+    return <Label className={classes.board}>{result}</Label>;
 });
 
 export interface IScoreboardProps {
@@ -24,7 +24,8 @@ interface IScoreboardStyle {
 const getClassNames = (): IScoreboardStyle =>
     mergeStyleSets({
         board: {
-            border: "1px solid darkgray",
+            display: "flex",
+            justifyContent: "center",
             padding: "5px 10px",
             fontSize: 16,
         },

--- a/src/components/TossupQuestion.tsx
+++ b/src/components/TossupQuestion.tsx
@@ -187,6 +187,7 @@ const getClassNames = (): ITossupQuestionClassNames =>
         },
         tossupQuestionText: {
             display: "inline-block",
+            marginBottom: "0.25em",
         },
         tossupText: {
             maxHeight: "37.5vh",

--- a/src/components/cycleItems/CycleItem.tsx
+++ b/src/components/cycleItems/CycleItem.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import { Label } from "@fluentui/react/lib/Label";
+import { Text } from "@fluentui/react";
 import { mergeStyleSets, memoizeFunction } from "@fluentui/react";
 
 import { CancelButton } from "../CancelButton";
@@ -14,7 +14,7 @@ export const CycleItem = observer(
 
         return (
             <div className={classes.eventContainer}>
-                <Label className={classes.eventText}>{props.text}</Label>
+                <Text variant="medium">{props.text}</Text>
                 {deleteButton}
             </div>
         );
@@ -30,7 +30,6 @@ export interface ICycleItemProps {
 
 interface ICycleItemClassNames {
     eventContainer: string;
-    eventText: string;
 }
 
 const getClassNames = memoizeFunction(
@@ -38,9 +37,6 @@ const getClassNames = memoizeFunction(
         mergeStyleSets({
             eventContainer: {
                 marginBottom: 5,
-            },
-            eventText: {
-                display: "inline",
             },
         })
 );

--- a/src/components/dialogs/NewGameDialog.tsx
+++ b/src/components/dialogs/NewGameDialog.tsx
@@ -31,7 +31,6 @@ import {
     assertNever,
 } from "@fluentui/react";
 
-import * as GameFormats from "src/state/GameFormats";
 import * as NewGameValidator from "src/state/NewGameValidator";
 import * as PendingNewGameUtils from "src/state/PendingNewGameUtils";
 import * as Sheets from "src/sheets/Sheets";
@@ -45,8 +44,9 @@ import { IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
 import { AppState } from "src/state/AppState";
 import { FromRostersTeamEntry } from "../FromRostersTeamEntry";
 import { SheetType } from "src/state/SheetState";
+import { GameFormatPicker } from "../GameFormatPicker";
 
-const playerListHeight = "25vh";
+const playerListHeight = "20vh";
 
 const enum PivotKey {
     Manual = "M",
@@ -176,6 +176,7 @@ const NewGameDialogBody = observer(
                 <Separator />
                 <PacketLoader appState={props.appState} onLoad={packetLoadHandler} />
                 <Separator />
+                <GameFormatPicker appState={props.appState} />
             </>
         );
     }
@@ -438,7 +439,7 @@ function onSubmit(props: INewGameDialogProps): void {
     game.loadPacket(pendingNewGame.packet);
 
     // TODO: Set the format from the user interface
-    game.setGameFormat(GameFormats.UndefinedGameFormat);
+    game.setGameFormat(pendingNewGame.gameFormat);
 
     // If we've just started a new game, start at the beginning
     uiState.setCycleIndex(0);
@@ -489,7 +490,7 @@ const getClassNames = (): INewGameDialogBodyClassNames =>
             display: "grid",
             gridTemplateColumns: "5fr 1fr 5fr",
             marginBottom: 20,
-            height: "40vh",
+            minHeight: "25vh",
             width: "50vw",
         },
         teamNameInput: {

--- a/src/state/GameFormats.ts
+++ b/src/state/GameFormats.ts
@@ -22,7 +22,7 @@ export const StandardPowersMACFGameFormat: IGameFormat = {
 
 export const UndefinedGameFormat: IGameFormat = {
     bonusesBounceBack: false,
-    displayName: "Sample format",
+    displayName: "Freeform format",
     minimumOvertimeQuestionCount: 1,
     overtimeIncludesBonuses: false,
     negValue: -5,

--- a/src/state/IPendingNewGame.ts
+++ b/src/state/IPendingNewGame.ts
@@ -1,4 +1,5 @@
 import { Cycle } from "./Cycle";
+import { IGameFormat } from "./IGameFormat";
 import { PacketState } from "./PacketState";
 import { Player } from "./TeamState";
 
@@ -28,4 +29,5 @@ export interface IPendingFromSheetsNewGame extends IBasePendingNewGame {
 
 interface IBasePendingNewGame {
     packet: PacketState;
+    gameFormat: IGameFormat;
 }

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -2,6 +2,7 @@ import { assertNever } from "@fluentui/react";
 import { makeAutoObservable } from "mobx";
 import { ignore } from "mobx-sync";
 
+import * as GameFormats from "./GameFormats";
 import { ITossupProtestEvent, IBonusProtestEvent } from "./Events";
 import { IPendingNewGame, PendingGameType } from "./IPendingNewGame";
 import { PacketState } from "./PacketState";
@@ -11,6 +12,7 @@ import { IStatus } from "../IStatus";
 import { IPendingSheet } from "./IPendingSheet";
 import { Cycle } from "./Cycle";
 import { DialogState } from "./DialogState";
+import { IGameFormat } from "./IGameFormat";
 
 // TODO: Look into breaking this up into individual UI component states. Lots of pendingX fields, which could be in
 // their own
@@ -117,6 +119,7 @@ export class UIState {
             firstTeamPlayers,
             secondTeamPlayers,
             type: PendingGameType.Manual,
+            gameFormat: GameFormats.ACFGameFormat,
         };
     }
 
@@ -161,6 +164,14 @@ export class UIState {
         if (this.pendingNewGame?.type === PendingGameType.Manual) {
             this.pendingNewGame.cycles = cycles;
         }
+    }
+
+    public setPendingNewGameFormat(gameFormat: IGameFormat): void {
+        if (this.pendingNewGame == undefined) {
+            return;
+        }
+
+        this.pendingNewGame.gameFormat = gameFormat;
     }
 
     public setPendingNewGameRosters(players: Player[]): void {
@@ -324,6 +335,7 @@ export class UIState {
 
     public resetSheetsId(): void {
         this.sheetsState.sheetId = undefined;
+        this.sheetsState.sheetType = undefined;
     }
 
     public showBuzzMenu(): void {

--- a/tests/NewGameValidatorTests.ts
+++ b/tests/NewGameValidatorTests.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import * as GameFormats from "src/state/GameFormats";
 import * as NewGameValidator from "src/state/NewGameValidator";
 import { IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
 import { Player } from "src/state/TeamState";
@@ -74,6 +75,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No players in second team", () => {
@@ -82,6 +84,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No players in first team (Lifsheets)", () => {
@@ -93,6 +96,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters: playersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No players in second team (Lifsheets)", () => {
@@ -104,6 +108,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters: [],
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Only empty names in first team", () => {
@@ -112,6 +117,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Only empty names in second team", () => {
@@ -120,6 +126,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Only empty names in first team (Lifsheets)", () => {
@@ -132,6 +139,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Only empty names in second team (Lifsheets)", () => {
@@ -144,6 +152,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Same player names in first team", () => {
@@ -152,6 +161,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Same player names in second team", () => {
@@ -164,6 +174,7 @@ describe("NewGameValidatorTests", () => {
                 ],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Same player names in first team (Lifsheets)", () => {
@@ -180,6 +191,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Same player names in second team (Lifsheets)", () => {
@@ -196,6 +208,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No starters in first team", () => {
@@ -204,6 +217,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No starters in second team", () => {
@@ -212,6 +226,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", false)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No starters in first team (Lifsheets)", () => {
@@ -224,6 +239,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No starters in second team (Lifsheets)", () => {
@@ -236,6 +252,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters,
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("No tossups in packet", () => {
@@ -244,6 +261,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: new PacketState(),
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Empty cycles array", () => {
@@ -253,6 +271,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             });
         });
         it("Valid game (Manual)", () => {
@@ -261,6 +280,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             };
             const result: boolean = NewGameValidator.isValid(newGame);
             expect(result).to.be.true;
@@ -272,6 +292,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
+                gameFormat: GameFormats.UndefinedGameFormat,
             };
             const result: boolean = NewGameValidator.isValid(newGame);
             expect(result).to.be.true;
@@ -286,6 +307,7 @@ describe("NewGameValidatorTests", () => {
                 secondTeamPlayersFromRosters: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Lifsheets,
+                gameFormat: GameFormats.UndefinedGameFormat,
             };
             const result: boolean = NewGameValidator.isValid(newGame);
             expect(result).to.be.true;


### PR DESCRIPTION
…d of Labels/divs in several cases

- Add a dropdown in the New Game dialog to let users pick the game format
  - Currently only ACF, ACF with Powers, and a freeform format are allowed
- At the end of the game, show an Export button instead of Next so the user can export more easily (#38)
- Rearrange the UI so that the scoreboard is above the cycle chooser
- Use the Text control instead of Labels or divs to use a consistent and easier-to-read font