### PR TITLE
Allow reader to customize the game format

### DIFF
--- a/src/components/EventViewer.tsx
+++ b/src/components/EventViewer.tsx
@@ -6,7 +6,7 @@ import { mergeStyleSets } from "@fluentui/react";
 import { CycleItemList } from "./cycleItems/CycleItemList";
 import { Cycle } from "src/state/Cycle";
 import { AppState } from "src/state/AppState";
-import { IGameFormat } from "src/state/IGameFormat";
+import { GameState } from "src/state/GameState";
 
 const numberKey = "number";
 const cycleKey = "cycle";
@@ -29,7 +29,7 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
                 return <></>;
             }
 
-            return onRenderItemColumn(item, props.appState.game.gameFormat, index, column);
+            return onRenderItemColumn(item, props.appState.game, index, column);
         },
         [props]
     );
@@ -75,7 +75,7 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
     );
 });
 
-function onRenderItemColumn(item: Cycle, gameFormat: IGameFormat, index: number, column: IColumn): JSX.Element {
+function onRenderItemColumn(item: Cycle, game: GameState, index: number, column: IColumn): JSX.Element {
     switch (column?.key) {
         case numberKey:
             if (index == undefined) {
@@ -89,7 +89,7 @@ function onRenderItemColumn(item: Cycle, gameFormat: IGameFormat, index: number,
 
             return (
                 <>
-                    <CycleItemList cycle={item} gameFormat={gameFormat} />
+                    <CycleItemList cycle={item} game={game} />
                     <Text>{`(${scoreInCurrentCycle[0]} - ${scoreInCurrentCycle[1]})`}</Text>
                 </>
             );

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -377,13 +377,22 @@ function getExportSubMenuItems(props: IGameBarProps): ICommandBarItemProps[] {
 function getOptionsSubMenuItems(props: IGameBarProps): ICommandBarItemProps[] {
     const items: ICommandBarItemProps[] = [];
 
-    items.push({
-        key: "font",
-        text: "Font...",
-        onClick: () => {
-            props.appState.uiState.setPendingQuestionFontSize(props.appState.uiState.questionFontSize);
+    items.push(
+        {
+            key: "changeFormat",
+            text: "Change Format...",
+            onClick: () => {
+                props.appState.uiState.dialogState.showCustomizeGameFormatDialog(props.appState.game.gameFormat);
+            },
         },
-    });
+        {
+            key: "font",
+            text: "Font...",
+            onClick: () => {
+                props.appState.uiState.setPendingQuestionFontSize(props.appState.uiState.questionFontSize);
+            },
+        }
+    );
 
     return items;
 }

--- a/src/components/GameFormatPicker.tsx
+++ b/src/components/GameFormatPicker.tsx
@@ -64,7 +64,7 @@ export const GameFormatPicker = observer((props: IGameFormatPickerProps) => {
                         <Text>{`Neg value: ${pendingNewGame.gameFormat.negValue}`}</Text>
                     </li>
                     <li>
-                        <Text>{`Has powers: ${formatBoolean(pendingNewGame.gameFormat.powerMarkers.length > 0)}`}</Text>
+                        <Text>{`Has powers: ${formatBoolean(pendingNewGame.gameFormat.powers.length > 0)}`}</Text>
                     </li>
                     <li>
                         <Text>{`Bonuses bounce back: ${formatBoolean(

--- a/src/components/ModalDialogContainer.tsx
+++ b/src/components/ModalDialogContainer.tsx
@@ -9,12 +9,14 @@ import { ExportToJsonDialog } from "./dialogs/ExportToJsonDialog";
 import { ImportGameDialog } from "./dialogs/ImportGameDialog";
 import { FontDialog } from "./dialogs/FontDialog";
 import { HelpDialog } from "./dialogs/HelpDialog";
+import { CustomizeGameFormatDialog } from "./dialogs/CustomizeGameFormatDialog";
 
 export const ModalDialogContainer = observer((props: IModalDialogContainerProps) => {
     // The Protest dialogs aren't here because they require extra information
     return (
         <>
             <AddPlayerDialog appState={props.appState} />
+            <CustomizeGameFormatDialog appState={props.appState} />
             <ExportToJsonDialog appState={props.appState} />
             <ExportToSheetsDialog appState={props.appState} />
             <FontDialog appState={props.appState} />

--- a/src/components/TossupQuestion.tsx
+++ b/src/components/TossupQuestion.tsx
@@ -36,7 +36,9 @@ export const TossupQuestion = observer(
             // We need to skip over power markers and not count them when we calculate buzz points
             let index: number | undefined = wordIndex;
             const trimmedText: string = fullText.trim();
-            const powerMarkerIndex: number = props.appState.game.gameFormat.powerMarkers.indexOf(trimmedText);
+            const powerMarkerIndex: number = props.appState.game.gameFormat.powers.findIndex(
+                (power) => power.marker === trimmedText
+            );
             if (powerMarkerIndex >= 0) {
                 index = undefined;
                 nonwordIndex++;

--- a/src/components/cycleItems/CycleItemList.tsx
+++ b/src/components/cycleItems/CycleItemList.tsx
@@ -20,11 +20,11 @@ import { ThrowOutQuestionCycleItem } from "./ThrowOutQuestionCycleItem";
 import { BonusAnswerCycleItem } from "./BonusAnswerCycleItem";
 import { TossupProtestCycleItem } from "./TossupProtestCycleItem";
 import { BonusProtestCycleItem } from "./BonusProtestCycleItem";
-import { IGameFormat } from "src/state/IGameFormat";
+import { GameState } from "src/state/GameState";
 
 export const CycleItemList = observer(
     (props: ICycleItemListProps): JSX.Element => {
-        return <div>{createCycleList(props.cycle, props.gameFormat)}</div>;
+        return <div>{createCycleList(props.cycle, props.game)}</div>;
     }
 );
 
@@ -32,7 +32,7 @@ export const CycleItemList = observer(
 // TODO: Investigate using List/DetailedList for this, instead of returning a bunch of individual elements
 // Consider making CycleItem take in a "data" field, that can be passed into the click handler. This will solve the
 // issue of making a new event handler each time
-function createCycleList(cycle: Cycle, gameFormat: IGameFormat): JSX.Element[] {
+function createCycleList(cycle: Cycle, game: GameState): JSX.Element[] {
     // Ordering should be
     // Substitutions
     // Buzzes and thrown out tossups, based on the tossup index. If a thrown out tossup and buzz have the same index,
@@ -105,7 +105,7 @@ function createCycleList(cycle: Cycle, gameFormat: IGameFormat): JSX.Element[] {
                 }
             }
 
-            elements.push(createTossupAnswerDetails(cycle, buzz, gameFormat, i));
+            elements.push(createTossupAnswerDetails(cycle, buzz, game, i));
         }
 
         // Ordering is still a little off, and the buzzes remain in view. Tweak this.
@@ -179,7 +179,7 @@ function createSubstitutionDetails(cycle: Cycle, sub: ISubstitutionEvent, index:
 function createTossupAnswerDetails(
     cycle: Cycle,
     buzz: ITossupAnswerEvent,
-    gameFormat: IGameFormat,
+    game: GameState,
     buzzIndex: number
 ): JSX.Element {
     // TODO: Look into using something like shortid for the key
@@ -188,7 +188,7 @@ function createTossupAnswerDetails(
             key={`buzz_${buzzIndex}_tu_${buzz.tossupIndex}_${buzz.marker.player.name}_${buzz.marker.player.teamName}`}
             cycle={cycle}
             buzz={buzz}
-            gameFormat={gameFormat}
+            game={game}
         />
     );
 }
@@ -237,5 +237,5 @@ function createBonusProtestDetails(cycle: Cycle, protest: IBonusProtestEvent, pr
 
 interface ICycleItemListProps {
     cycle: Cycle;
-    gameFormat: IGameFormat;
+    game: GameState;
 }

--- a/src/components/cycleItems/TossupAnswerCycleItem.tsx
+++ b/src/components/cycleItems/TossupAnswerCycleItem.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react-lite";
 import { Cycle } from "src/state/Cycle";
 import { ITossupAnswerEvent } from "src/state/Events";
 import { CycleItem } from "./CycleItem";
-import { IGameFormat } from "src/state/IGameFormat";
+import { GameState } from "src/state/GameState";
 
 export const TossupAnswerCycleItem = observer(
     (props: ITossupAnswerCycleItemProps): JSX.Element => {
@@ -12,24 +12,24 @@ export const TossupAnswerCycleItem = observer(
             if (props.buzz.marker.points > 0) {
                 props.cycle.removeCorrectBuzz();
             } else {
-                props.cycle.removeWrongBuzz(props.buzz.marker.player, props.gameFormat);
+                props.cycle.removeWrongBuzz(props.buzz.marker.player, props.game.gameFormat);
             }
         };
 
         let buzzDescription = "answered";
-        const points: number = props.buzz.marker.points;
+        const points: number = props.game.getBuzzValue(props.buzz);
         if (points === 0) {
             buzzDescription = "answered WRONGLY";
-        } else if (points === props.gameFormat.negValue) {
+        } else if (points === props.game.gameFormat.negValue) {
             buzzDescription = "NEGGED";
         } else if (points === 10) {
             buzzDescription = "answered CORRECTLY";
         } else {
-            const powerIndex: number = props.gameFormat.pointsForPowers.indexOf(points);
+            const powerIndex: number = props.game.gameFormat.powers.findIndex((power) => power.points === points);
             // Add more "SUPER"s depending on the number of remaining power levels
             // Subtract 1 since the first element is for regular powers
-            const superpowerLevel: number = props.gameFormat.pointsForPowers.length - powerIndex - 1;
-            if (superpowerLevel === 0) {
+            const superpowerLevel: number = props.game.gameFormat.powers.length - powerIndex - 1;
+            if (superpowerLevel === 0 || powerIndex === -1) {
                 buzzDescription = "POWERED";
             } else {
                 // Treat the 0 case as special since we don't want to create empty arrays for no reason
@@ -47,5 +47,5 @@ export const TossupAnswerCycleItem = observer(
 export interface ITossupAnswerCycleItemProps {
     cycle: Cycle;
     buzz: ITossupAnswerEvent;
-    gameFormat: IGameFormat;
+    game: GameState;
 }

--- a/src/components/dialogs/CustomizeGameFormatDialog.tsx
+++ b/src/components/dialogs/CustomizeGameFormatDialog.tsx
@@ -1,0 +1,378 @@
+import * as React from "react";
+import { observer } from "mobx-react-lite";
+import {
+    IDialogContentProps,
+    DialogType,
+    IModalProps,
+    ContextualMenu,
+    Dialog,
+    DialogFooter,
+    PrimaryButton,
+    DefaultButton,
+    Stack,
+    Checkbox,
+    StackItem,
+    SpinButton,
+    IStackTokens,
+    Label,
+    ILabelStyles,
+    TextField,
+} from "@fluentui/react";
+
+import { GameState } from "src/state/GameState";
+import { AppState } from "src/state/AppState";
+import { IGameFormat, IPowerMarker } from "src/state/IGameFormat";
+import { CustomizeGameFormatDialogState } from "src/state/CustomizeGameFormatDialogState";
+
+const customFormatName = "Custom";
+
+const content: IDialogContentProps = {
+    type: DialogType.normal,
+    title: "Customize Game Format",
+    closeButtonAriaLabel: "Close",
+    showCloseButton: true,
+    styles: {
+        innerContent: {
+            display: "flex",
+            flexDirection: "column",
+        },
+    },
+};
+
+const modalProps: IModalProps = {
+    isBlocking: false,
+    dragOptions: {
+        moveMenuItemText: "Move",
+        closeMenuItemText: "Close",
+        menu: ContextualMenu,
+    },
+    styles: {
+        main: {
+            top: "15vh",
+        },
+    },
+    topOffsetFixed: true,
+};
+
+const headerStyles: Partial<ILabelStyles> = {
+    root: {
+        fontSize: 16,
+    },
+};
+
+const settingsStackTokens: Partial<IStackTokens> = { childrenGap: 10 };
+
+const sectionsStackTokens: Partial<IStackTokens> = { childrenGap: 20 };
+
+// TODO: Look into making a DefaultDialog, which handles the footers and default props
+export const CustomizeGameFormatDialog = observer(
+    (props: ICustomizeGameFormatDialogProps): JSX.Element => {
+        const submitHandler = React.useCallback(() => onSubmit(props), [props]);
+        const cancelHandler = React.useCallback(() => onCancel(props), [props]);
+
+        return (
+            <Dialog
+                hidden={props.appState.uiState.dialogState.customizeGameFormat === undefined}
+                dialogContentProps={content}
+                modalProps={modalProps}
+                onDismiss={cancelHandler}
+            >
+                <CustomizeGameFormatDialogBody {...props} />
+                <DialogFooter>
+                    <PrimaryButton text="Save" onClick={submitHandler} />
+                    <DefaultButton text="Cancel" onClick={cancelHandler} />
+                </DialogFooter>
+            </Dialog>
+        );
+    }
+);
+
+const CustomizeGameFormatDialogBody = observer(
+    (props: ICustomizeGameFormatDialogProps): JSX.Element => {
+        const customizeGameFormatState: CustomizeGameFormatDialogState | undefined =
+            props.appState.uiState.dialogState.customizeGameFormat;
+
+        const regulationTossupCountChangeHandler = React.useCallback(
+            (event: React.SyntheticEvent<HTMLElement, Event>, newValue?: string | undefined) => {
+                const count: number | undefined = getNumberOrUndefined(newValue);
+                if (count != undefined) {
+                    customizeGameFormatState?.updateGameFormat({ regulationTossupCount: count });
+                }
+            },
+            [customizeGameFormatState]
+        );
+
+        const negValueChangeHandler = React.useCallback(
+            (event: React.SyntheticEvent<HTMLElement, Event>, newValue?: string | undefined) => {
+                const negValue: number | undefined = getNumberOrUndefined(newValue);
+                if (negValue != undefined) {
+                    customizeGameFormatState?.updateGameFormat({ negValue });
+                }
+            },
+            [customizeGameFormatState]
+        );
+
+        const powerMarkersHandler = React.useCallback(
+            (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+                if (newValue == undefined) {
+                    return;
+                } else if (newValue.trim() === "") {
+                    customizeGameFormatState?.setPowerMarkers([]);
+                    return;
+                }
+
+                // TODO: Handle power markers with commas, which would require handling escapes
+                const powerMarkers: string[] = newValue.split(",").map((value) => value.trim());
+                customizeGameFormatState?.setPowerMarkers(powerMarkers);
+            },
+            [customizeGameFormatState]
+        );
+
+        const powerValuesHandler = React.useCallback(
+            (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+                if (newValue == undefined) {
+                    return;
+                } else if (newValue.trim() === "") {
+                    customizeGameFormatState?.setPowerValues([]);
+                    return;
+                }
+
+                const pointsForPowers: number[] = newValue.split(",").map((value) => parseInt(value, 10));
+                if (pointsForPowers.some((value) => isNaN(value))) {
+                    return;
+                }
+
+                customizeGameFormatState?.setPowerValues(pointsForPowers);
+            },
+            [customizeGameFormatState]
+        );
+
+        const minimumQuestionsInOvertimeChangeHandler = React.useCallback(
+            (event: React.SyntheticEvent<HTMLElement, Event>, newValue?: string | undefined) => {
+                const minimumOvertimeQuestionCount: number | undefined = getNumberOrUndefined(newValue);
+                if (minimumOvertimeQuestionCount != undefined) {
+                    customizeGameFormatState?.updateGameFormat({ minimumOvertimeQuestionCount });
+                }
+            },
+            [customizeGameFormatState]
+        );
+
+        const bouncebackChangeHandler = React.useCallback(
+            (ev?: React.FormEvent<HTMLInputElement | HTMLElement>, checked?: boolean) => {
+                if (checked == undefined) {
+                    return;
+                }
+
+                customizeGameFormatState?.updateGameFormat({ bonusesBounceBack: checked });
+            },
+            [customizeGameFormatState]
+        );
+
+        const overtimeBonusesChangeHandler = React.useCallback(
+            (ev?: React.FormEvent<HTMLInputElement | HTMLElement>, checked?: boolean) => {
+                if (checked == undefined) {
+                    return;
+                }
+
+                customizeGameFormatState?.updateGameFormat({ overtimeIncludesBonuses: checked });
+            },
+            [customizeGameFormatState]
+        );
+
+        const powerValidationHandler = React.useCallback(() => {
+            if (customizeGameFormatState == undefined) {
+                return;
+            }
+
+            if (customizeGameFormatState.powerMarkers.length < customizeGameFormatState.powerValues.length) {
+                customizeGameFormatState.setPowerMarkerErrorMessage(
+                    "More power markers needed. The number of power markers and values must be the same."
+                );
+            } else if (customizeGameFormatState.powerValues.length < customizeGameFormatState.powerMarkers.length) {
+                customizeGameFormatState.setPowerValuesErrorMessage(
+                    "More values needed. The number of power markers and values must be the same."
+                );
+            } else {
+                customizeGameFormatState.clearPowerErrorMessages();
+            }
+        }, [customizeGameFormatState]);
+
+        if (customizeGameFormatState == undefined) {
+            return <></>;
+        }
+
+        const gameFormat: IGameFormat | undefined = customizeGameFormatState.gameFormat;
+
+        return (
+            <Stack tokens={sectionsStackTokens}>
+                <StackItem>
+                    <Stack tokens={settingsStackTokens}>
+                        <StackItem>
+                            <Label styles={headerStyles}>Game length</Label>
+                        </StackItem>
+                        <StackItem>
+                            <SpinButton
+                                label="Tossups in regulation"
+                                onChange={regulationTossupCountChangeHandler}
+                                value={gameFormat.regulationTossupCount.toString()}
+                                min={1}
+                                max={999}
+                                incrementButtonAriaLabel={"Increase number of tossups in regulation by 1"}
+                                decrementButtonAriaLabel={"Decrease number of tossups in regulation by 1"}
+                            />
+                        </StackItem>
+                        <StackItem>
+                            <SpinButton
+                                label="Minimum number of questions in overtime"
+                                onChange={minimumQuestionsInOvertimeChangeHandler}
+                                value={gameFormat.minimumOvertimeQuestionCount.toString()}
+                                min={1}
+                                max={99}
+                                incrementButtonAriaLabel={"Increase minimum number of questions in overtime by 1"}
+                                decrementButtonAriaLabel={"Decrease minimum number of questions in overtime by 1"}
+                            />
+                        </StackItem>
+                    </Stack>
+                </StackItem>
+
+                <StackItem>
+                    <Stack tokens={settingsStackTokens}>
+                        <StackItem>
+                            <Label styles={headerStyles}>Scoring</Label>
+                        </StackItem>
+                        <StackItem>
+                            <SpinButton
+                                label="Neg value"
+                                onChange={negValueChangeHandler}
+                                value={gameFormat.negValue.toString()}
+                                min={-100}
+                                max={0}
+                                step={5}
+                                incrementButtonAriaLabel={"Increase neg value by 5"}
+                                decrementButtonAriaLabel={"Decrease neg value by 5"}
+                            />
+                        </StackItem>
+                        <StackItem>
+                            <TextField
+                                errorMessage={customizeGameFormatState.powerMarkerErrorMessage}
+                                label="Power markers (comma separated)"
+                                onBlur={powerValidationHandler}
+                                onChange={powerMarkersHandler}
+                                value={customizeGameFormatState.powerMarkers.join(",")}
+                            />
+                        </StackItem>
+                        <StackItem>
+                            <TextField
+                                defaultValue={customizeGameFormatState.powerValues.join(",")}
+                                errorMessage={customizeGameFormatState.powerValuesErrorMessage}
+                                label="Power values (comma separated, descending order)"
+                                onBlur={powerValidationHandler}
+                                onChange={powerValuesHandler}
+                            />
+                        </StackItem>
+                    </Stack>
+                </StackItem>
+
+                <StackItem>
+                    <Stack tokens={settingsStackTokens}>
+                        <StackItem>
+                            <Label styles={headerStyles}>Bonus settings</Label>
+                        </StackItem>
+                        <StackItem>
+                            <Checkbox
+                                label="Bonuses bounce back"
+                                checked={gameFormat.bonusesBounceBack}
+                                onChange={bouncebackChangeHandler}
+                            />
+                        </StackItem>
+                        <StackItem>
+                            <Checkbox
+                                label="Overtime includes bonuses"
+                                checked={gameFormat.overtimeIncludesBonuses}
+                                onChange={overtimeBonusesChangeHandler}
+                            />
+                        </StackItem>
+                    </Stack>
+                </StackItem>
+            </Stack>
+        );
+    }
+);
+
+function getNumberOrUndefined(value: string | undefined): number | undefined {
+    if (value == undefined) {
+        return undefined;
+    }
+
+    const number = Number.parseInt(value, 10);
+    return isNaN(number) ? undefined : number;
+}
+
+function onSubmit(props: ICustomizeGameFormatDialogProps): void {
+    const game: GameState = props.appState.game;
+    const state: CustomizeGameFormatDialogState | undefined = props.appState.uiState.dialogState.customizeGameFormat;
+    if (state == undefined) {
+        throw new Error("Tried customizing a game format with no game format");
+    }
+
+    if (!isGameFormatValid(props)) {
+        // We should already have the error repored, so just do nothing
+        return;
+    }
+
+    const updatedGameFormat: IGameFormat = state.gameFormat;
+    if (updatedGameFormat.displayName !== customFormatName) {
+        // TS will complain about implicit any if we use Object.keys to do a deep comparison, so cast the objects as any,
+        // and then do a deep comparison
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyUpdatedGameFormat: any = updatedGameFormat as any;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyExistingGameFormat: any = game.gameFormat as any;
+
+        for (const key of Object.keys(updatedGameFormat)) {
+            if (anyUpdatedGameFormat[key] !== anyExistingGameFormat[key]) {
+                updatedGameFormat.displayName = customFormatName;
+                break;
+            }
+        }
+    }
+
+    // Power values should be in descending order, so sort them before saving the game format
+    const powers: IPowerMarker[] = [];
+    for (let i = 0; i < state.powerMarkers.length; i++) {
+        powers.push({ marker: state.powerMarkers[i], points: state.powerValues[i] });
+    }
+
+    powers.sort(sortPowersDescending);
+    updatedGameFormat.powers = powers;
+
+    game.setGameFormat(updatedGameFormat);
+
+    hideDialog(props);
+}
+
+function sortPowersDescending(left: IPowerMarker, right: IPowerMarker): number {
+    return right.points - left.points;
+}
+
+function isGameFormatValid(props: ICustomizeGameFormatDialogProps): boolean {
+    const state: CustomizeGameFormatDialogState | undefined = props.appState.uiState.dialogState.customizeGameFormat;
+    if (state == undefined) {
+        throw new Error("Tried changing a format with no modified format");
+    }
+
+    return state.powerMarkerErrorMessage == undefined && state.powerValuesErrorMessage == undefined;
+}
+
+function onCancel(props: ICustomizeGameFormatDialogProps): void {
+    hideDialog(props);
+}
+
+function hideDialog(props: ICustomizeGameFormatDialogProps): void {
+    props.appState.uiState.dialogState.hideCustomizeGameFormatDialog();
+}
+
+export interface ICustomizeGameFormatDialogProps {
+    appState: AppState;
+}

--- a/src/sheets/ISheetsGenerator.ts
+++ b/src/sheets/ISheetsGenerator.ts
@@ -31,6 +31,9 @@ export interface ISheetsGenerator {
     // Should be maximum number of cycles, inclusive, i.e. if the scoresheet only has 20 cells for scoring, then 20
     readonly cyclesLimit: number;
 
+    // If the Sheet needs to record buzzes that have no penalty (0 points)
+    readonly writeNoPenaltyBuzzes: boolean;
+
     // TODO: Method to generate player/column mapping... and maybe we pass that in? Could also just have starting
     // columns for each player
     // Means we can't support horizontal-based scoresheets
@@ -72,12 +75,14 @@ export interface ISheetsGenerator {
     ): gapi.client.sheets.ValueRange[];
     getValuesForCorrectBuzz(
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
     ): gapi.client.sheets.ValueRange[];
     getValuesForNeg(
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number

--- a/src/sheets/LifsheetsGenerator.ts
+++ b/src/sheets/LifsheetsGenerator.ts
@@ -21,6 +21,7 @@ export const LifsheetsGenerator: ISheetsGenerator = {
     playerPerTeamLimit: 6,
     playerRow: 7,
     rostersRange: "Rosters!A2:L",
+    writeNoPenaltyBuzzes: false,
 
     getClearRanges: (sheetName: string): string[] => {
         return [
@@ -118,8 +119,13 @@ export const LifsheetsGenerator: ISheetsGenerator = {
 
         return valueRanges;
     },
-    getValuesForDeadQuestion: (): gapi.client.sheets.ValueRange[] => {
-        return [];
+    getValuesForDeadQuestion: (sheetName: string, row: number): gapi.client.sheets.ValueRange[] => {
+        return [
+            {
+                range: `'${sheetName}'!Q${row}`,
+                values: [[1]],
+            },
+        ];
     },
     getValuesForPlayerJoins: (
         join: IPlayerJoinsEvent,
@@ -211,6 +217,7 @@ export const LifsheetsGenerator: ISheetsGenerator = {
     },
     getValuesForCorrectBuzz: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -223,12 +230,13 @@ export const LifsheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                values: [[buzz.marker.points ?? 10]],
+                values: [[points]],
             },
         ];
     },
     getValuesForNeg: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -241,8 +249,7 @@ export const LifsheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: Calculate if this is a power or not
-                values: [[-5]],
+                values: [[points]],
             },
         ];
     },

--- a/src/sheets/TJSheetsGenerator.ts
+++ b/src/sheets/TJSheetsGenerator.ts
@@ -22,6 +22,7 @@ export const TJSheetsGenerator: ISheetsGenerator = {
     playerPerTeamLimit: 6,
     playerRow,
     rostersRange: "INSTRUCTIONS!A34:CV40",
+    writeNoPenaltyBuzzes: false,
 
     getClearRanges: (sheetName: string): string[] => {
         return [
@@ -217,6 +218,7 @@ export const TJSheetsGenerator: ISheetsGenerator = {
     },
     getValuesForCorrectBuzz: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -229,12 +231,13 @@ export const TJSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                values: [[buzz.marker.points ?? 10]],
+                values: [[points]],
             },
         ];
     },
     getValuesForNeg: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -247,8 +250,7 @@ export const TJSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: When formats are supported, figure out what value goes here (and return nothing if it's 0)
-                values: [[-5]],
+                values: [[points]],
             },
         ];
     },

--- a/src/sheets/UCSDSheetsGenerator.ts
+++ b/src/sheets/UCSDSheetsGenerator.ts
@@ -15,6 +15,7 @@ export const UCSDSheetsGenerator: ISheetsGenerator = {
     playerPerTeamLimit: 6,
     playerRow: 3,
     rostersRange: "Rosters!A1:G",
+    writeNoPenaltyBuzzes: false,
 
     getClearRanges: (sheetName: string): string[] => {
         return [
@@ -110,6 +111,7 @@ export const UCSDSheetsGenerator: ISheetsGenerator = {
     },
     getValuesForCorrectBuzz: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -122,12 +124,13 @@ export const UCSDSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                values: [[buzz.marker.points ?? 10]],
+                values: [[points]],
             },
         ];
     },
     getValuesForNeg: (
         buzz: ITossupAnswerEvent,
+        points: number,
         playerToColumnMapping: IPlayerToColumnMap,
         sheetName: string,
         row: number
@@ -140,8 +143,7 @@ export const UCSDSheetsGenerator: ISheetsGenerator = {
         return [
             {
                 range: `'${sheetName}'!${column}${row}`,
-                // TODO: Calculate if this is a power or not
-                values: [[-5]],
+                values: [[points]],
             },
         ];
     },

--- a/src/state/CustomizeGameFormatDialogState.ts
+++ b/src/state/CustomizeGameFormatDialogState.ts
@@ -1,0 +1,52 @@
+import { makeAutoObservable } from "mobx";
+import { IGameFormat } from "./IGameFormat";
+
+export class CustomizeGameFormatDialogState {
+    public gameFormat: IGameFormat;
+
+    // Based on the UI, we have to store powerMarkers/powerValues separately. This is a bit of a leaky abstraction
+    // (state shouldn't know about the view), which we should try to fix
+    public powerMarkers: string[];
+
+    public powerValues: number[];
+
+    public powerMarkerErrorMessage: string | undefined;
+
+    public powerValuesErrorMessage: string | undefined;
+
+    constructor(existingGameFormat: IGameFormat) {
+        makeAutoObservable(this);
+
+        this.gameFormat = { ...existingGameFormat };
+        this.powerMarkers = this.gameFormat.powers.map((power) => power.marker);
+        this.powerMarkerErrorMessage = undefined;
+
+        this.powerValues = this.gameFormat.powers.map((power) => power.points);
+        this.powerValuesErrorMessage = undefined;
+    }
+
+    public clearPowerErrorMessages(): void {
+        this.powerMarkerErrorMessage = undefined;
+        this.powerValuesErrorMessage = undefined;
+    }
+
+    public setPowerMarkers(powerMarkers: string[]): void {
+        this.powerMarkers = powerMarkers;
+    }
+
+    public setPowerMarkerErrorMessage(message: string): void {
+        this.powerMarkerErrorMessage = message;
+    }
+
+    public setPowerValues(powerValues: number[]): void {
+        this.powerValues = powerValues;
+    }
+
+    public setPowerValuesErrorMessage(message: string): void {
+        this.powerValuesErrorMessage = message;
+    }
+
+    public updateGameFormat(gameFormatUpdate: Partial<IGameFormat>): void {
+        this.gameFormat = { ...this.gameFormat, ...gameFormatUpdate };
+    }
+}

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -1,9 +1,11 @@
 import { makeAutoObservable } from "mobx";
 import { ignore } from "mobx-sync";
+import { CustomizeGameFormatDialogState } from "./CustomizeGameFormatDialogState";
+import { IGameFormat } from "./IGameFormat";
 
 export class DialogState {
     @ignore
-    public editFormatDialogVisible: boolean;
+    public customizeGameFormat: CustomizeGameFormatDialogState | undefined;
 
     @ignore
     public exportToJsonDialogVisible: boolean;
@@ -20,15 +22,15 @@ export class DialogState {
     constructor() {
         makeAutoObservable(this);
 
-        this.editFormatDialogVisible = false;
+        this.customizeGameFormat = undefined;
         this.exportToJsonDialogVisible = false;
         this.helpDialogVisible = false;
         this.importGameDialogVisible = false;
         this.newGameDialogVisible = false;
     }
 
-    public hideEditFormatDialog(): void {
-        this.editFormatDialogVisible = false;
+    public hideCustomizeGameFormatDialog(): void {
+        this.customizeGameFormat = undefined;
     }
 
     public hideExportToJsonDialog(): void {
@@ -47,8 +49,8 @@ export class DialogState {
         this.newGameDialogVisible = false;
     }
 
-    public showEditFormatDialog(): void {
-        this.editFormatDialogVisible = true;
+    public showCustomizeGameFormatDialog(gameFormat: IGameFormat): void {
+        this.customizeGameFormat = new CustomizeGameFormatDialogState(gameFormat);
     }
 
     public showExportToJsonDialog(): void {

--- a/src/state/IBuzzMarker.ts
+++ b/src/state/IBuzzMarker.ts
@@ -4,5 +4,9 @@ export interface IBuzzMarker {
     isLastWord?: boolean;
     position: number;
     player: IPlayer;
+
+    // This is just a snapshot of how much the question was worth when it was scored. For the true point value, we
+    // should rely on Tossup.getPointsAtPosition with the position field passed in.
+    // TODO: We may want to change this to "isCorrect" to simplify the logic in some places
     points: number;
 }

--- a/src/state/IGameFormat.ts
+++ b/src/state/IGameFormat.ts
@@ -2,6 +2,7 @@
 // since it covers much of the same ground
 // We may need to add additional rules, though, such as if powers are supported
 // TODO: We should have an enum for when substitutions are allowed
+// TODO: Consider adding a field for how many points gets are worth
 
 export interface IGameFormat {
     regulationTossupCount: number;
@@ -10,14 +11,22 @@ export interface IGameFormat {
     bonusesBounceBack: boolean;
     negValue: number;
 
+    // Both of these are deprecated
+    pointsForPowers?: number[];
+    powerMarkers?: string[];
+
     // Empty array means that powers aren't supported
     // This array must be in descending order
-    pointsForPowers: number[];
-    powerMarkers: string[];
+    powers: IPowerMarker[];
 
     timeoutsAllowed: number;
     displayName: string;
 
     // Tells us which version this format was generated from, so we can support backwards compatibility if possible
     version: string;
+}
+
+export interface IPowerMarker {
+    marker: string;
+    points: number;
 }

--- a/src/state/PacketState.ts
+++ b/src/state/PacketState.ts
@@ -69,7 +69,7 @@ export class Tossup implements IQuestion {
 
     public getPointsAtPosition(format: IGameFormat, wordIndex: number, isCorrect = true): number {
         // If there's no powers, default to 10 points
-        if (format.powerMarkers.length === 0 && isCorrect) {
+        if (format.powers.length === 0 && isCorrect) {
             return 10;
         }
 
@@ -87,8 +87,8 @@ export class Tossup implements IQuestion {
         // One potential optimization would be to remove all the words up to that index if we find it, so we have to
         // look through less words
         let powerMarkersFound = 0;
-        for (let i = 0; i < format.powerMarkers.length; i++) {
-            const powerMarker: string = format.powerMarkers[i];
+        for (let i = 0; i < format.powers.length; i++) {
+            const powerMarker: string = format.powers[i].marker;
             const powerMarkerIndex: number = words.indexOf(powerMarker);
 
             // TODO: When we skip over pronunication guides, we'll need to calculate how many words they take up, so
@@ -106,7 +106,7 @@ export class Tossup implements IQuestion {
                     powerMarkerIndex !== lastWordIndex &&
                     wordIndex <= powerMarkerIndex - (powerMarkersFound + 1)
                 ) {
-                    return format.pointsForPowers[i];
+                    return format.powers[i].points;
                 }
 
                 powerMarkersFound++;

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -15,7 +15,7 @@ import { DialogState } from "./DialogState";
 import { IGameFormat } from "./IGameFormat";
 
 // TODO: Look into breaking this up into individual UI component states. Lots of pendingX fields, which could be in
-// their own
+// their own (see CustomizeGameFormatDialogState)
 // Alternatively, keep certain component-local states in the component state, and only store values that could be used
 // outside of that component here.
 

--- a/tests/PacketStateTossupTests.ts
+++ b/tests/PacketStateTossupTests.ts
@@ -8,13 +8,14 @@ import { IGameFormat } from "src/state/IGameFormat";
 const noPowersGameFormat: IGameFormat = { ...GameFormats.UndefinedGameFormat, powerMarkers: [], pointsForPowers: [] };
 const powersGameFormat: IGameFormat = {
     ...GameFormats.UndefinedGameFormat,
-    powerMarkers: ["(*)"],
-    pointsForPowers: [15],
+    powers: [{ marker: "(*)", points: 15 }],
 };
 const superpowersGameFormat: IGameFormat = {
     ...GameFormats.UndefinedGameFormat,
-    powerMarkers: ["(+)", "(*)"],
-    pointsForPowers: [20, 15],
+    powers: [
+        { marker: "(+)", points: 20 },
+        { marker: "(*)", points: 15 },
+    ],
 };
 
 describe("PacketStateTossupTests", () => {

--- a/tests/QBJTests.ts
+++ b/tests/QBJTests.ts
@@ -20,7 +20,7 @@ const defaultPacket: PacketState = new PacketState();
 defaultPacket.setTossups([
     new Tossup("first q", "first a"),
     new Tossup("second q", "second a"),
-    new Tossup("third q", "third a"),
+    new Tossup("third q (*) has a power marker", "third a"),
     new Tossup("fourth q", "fourth a"),
 ]);
 defaultPacket.setBonuses([
@@ -143,7 +143,7 @@ describe("QBJTests", () => {
                             player: secondTeamPlayer,
                             points: 15,
                             position: 0,
-                            isLastWord: true,
+                            isLastWord: false,
                         },
                         2,
                         game.gameFormat,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,9 @@ module.exports = (env, argv) => {
                 __GOOGLE_CLIENT_ID__: JSON.stringify(
                     "1038902414768-nj056sbrbe0oshavft2uq9et6tvbu2d5.apps.googleusercontent.com"
                 ),
-                // If you're testing the YAPP Azure Function locally, use http://localhost:7071/api/ParseDocx
+                // If you're testing the YAPP Azure Function locally, use http://localhost:7071/api/ParseDocx, and
+                // make sure local.settings.json includes this after the Values field:
+                // "Host": { "LocalHttpPort": 7071, "CORS": "*" }
                 __YAPP_SERVICE__: JSON.stringify(
                     "https://yetanotherpacketparserazurefunction.azurewebsites.net/api/ParseDocx"
                 ),


### PR DESCRIPTION
- Allow the reader to customize the game format in a dialog (#74)
-  Mark dead tossups explicitly in Lifsheets (#75)
- Various data structure changes
    - Merge powerMarkers and pointsForPowers arrays into one (#77)
    - Make cycles always calculate points instead of storing them when scored
        - This allows changes to the game format to immediately update the score