### PR TITLE
Use React.useContext where appropriate

### DIFF
--- a/src/components/EventViewer.tsx
+++ b/src/components/EventViewer.tsx
@@ -7,20 +7,22 @@ import { CycleItemList } from "./cycleItems/CycleItemList";
 import { Cycle } from "src/state/Cycle";
 import { AppState } from "src/state/AppState";
 import { GameState } from "src/state/GameState";
+import { StateContext } from "src/contexts/StateContext";
 
 const numberKey = "number";
 const cycleKey = "cycle";
 
-export const EventViewer = observer((props: IEventViewerProps): JSX.Element | null => {
+export const EventViewer = observer((): JSX.Element | null => {
+    const appState: AppState = React.useContext(StateContext);
     const classes: IEventViewerClassNames = getClassNames();
 
     const activeItemChangedHandler = React.useCallback(
         (item: IEventViewerRow, index?: number) => {
             if (index != undefined) {
-                props.appState.uiState.setCycleIndex(index);
+                appState.uiState.setCycleIndex(index);
             }
         },
-        [props.appState.uiState]
+        [appState.uiState]
     );
 
     const renderColumnHandler = React.useCallback(
@@ -29,9 +31,9 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
                 return <></>;
             }
 
-            return onRenderItemColumn(item, props.appState.game, index, column);
+            return onRenderItemColumn(item, appState.game, index, column);
         },
-        [props]
+        [appState]
     );
 
     const columns: IColumn[] = [
@@ -57,7 +59,7 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
             // TODO: Consider adding autoruns for scores/finalScore so we don't have to consider what context it's run
             // in. Just swapping scores with a scores2 value set during autorun didn't work initially, so it needs more
             // investigation.
-            data: props.appState.game.scores.slice(0, props.appState.game.playableCycles.length),
+            data: appState.game.scores.slice(0, appState.game.playableCycles.length),
         },
     ];
 
@@ -67,7 +69,7 @@ export const EventViewer = observer((props: IEventViewerProps): JSX.Element | nu
                 checkboxVisibility={CheckboxVisibility.hidden}
                 selectionMode={SelectionMode.single}
                 columns={columns}
-                items={props.appState.game.playableCycles}
+                items={appState.game.playableCycles}
                 onActiveItemChanged={activeItemChangedHandler}
                 onRenderItemColumn={renderColumnHandler}
             />
@@ -96,10 +98,6 @@ function onRenderItemColumn(item: Cycle, game: GameState, index: number, column:
         default:
             return <></>;
     }
-}
-
-export interface IEventViewerProps {
-    appState: AppState;
 }
 
 interface IEventViewerClassNames {

--- a/src/components/GameFormatPicker.tsx
+++ b/src/components/GameFormatPicker.tsx
@@ -5,6 +5,7 @@ import { Dropdown, IDropdownOption, IDropdownStyles, ITextStyles, Stack, StackIt
 import * as GameFormats from "src/state/GameFormats";
 import { AppState } from "src/state/AppState";
 import { IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
+import { StateContext } from "src/contexts/StateContext";
 
 const dropdownStyles: Partial<IDropdownStyles> = {
     root: {
@@ -19,17 +20,18 @@ const bouncebackWarningStyles: Partial<ITextStyles> = {
     },
 };
 
-export const GameFormatPicker = observer((props: IGameFormatPickerProps) => {
+export const GameFormatPicker = observer(() => {
+    const appState: AppState = React.useContext(StateContext);
     const changeHandler = React.useCallback(
         (ev: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
             if (option?.data != undefined) {
-                props.appState.uiState.setPendingNewGameFormat(option.data);
+                appState.uiState.setPendingNewGameFormat(option.data);
             }
         },
-        [props]
+        [appState]
     );
 
-    const pendingNewGame: IPendingNewGame | undefined = props.appState.uiState.pendingNewGame;
+    const pendingNewGame: IPendingNewGame | undefined = appState.uiState.pendingNewGame;
 
     if (pendingNewGame == undefined) {
         return null;
@@ -80,8 +82,4 @@ export const GameFormatPicker = observer((props: IGameFormatPickerProps) => {
 
 function formatBoolean(value: boolean): string {
     return value ? "Yes" : "No";
-}
-
-export interface IGameFormatPickerProps {
-    appState: AppState;
 }

--- a/src/components/GameViewer.tsx
+++ b/src/components/GameViewer.tsx
@@ -7,14 +7,13 @@ import { Scoreboard } from "./Scoreboard";
 import { EventViewer } from "./EventViewer";
 import { GameBar } from "./GameBar";
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
 const scoreboardAndQuestionViewerTokens: IStackTokens = { childrenGap: 20 };
 
-// TODO: Figure out CSS to prevent the content from growing too much. GameViewer should probably have like 90/100% of
-// the height. We need to make sure the contents also don't grow beyond the page, and add overflow handling to the
-// viewer containers
-export const GameViewer = observer((props: IGameViewerProps) => {
-    const gameExists: boolean = props.appState.game.isLoaded;
+export const GameViewer = observer(() => {
+    const appState: AppState = React.useContext(StateContext);
+    const gameExists: boolean = appState.game.isLoaded;
     const classes: IGameViewerClassNames = getClassNames(gameExists);
 
     // TODO: See if we should convert the game viewer section into a StackItem. It's using a grid now, so it might
@@ -22,30 +21,26 @@ export const GameViewer = observer((props: IGameViewerProps) => {
     return (
         <Stack>
             <StackItem>
-                <GameBar appState={props.appState} />
+                <GameBar />
             </StackItem>
             <div className={classes.gameViewer}>
                 <StackItem className={classes.questionViewerContainer}>
                     <Stack tokens={scoreboardAndQuestionViewerTokens}>
                         <StackItem>
-                            <Scoreboard appState={props.appState} />
+                            <Scoreboard />
                         </StackItem>
                         <StackItem>
-                            <QuestionViewerContainer appState={props.appState}></QuestionViewerContainer>
+                            <QuestionViewerContainer />
                         </StackItem>
                     </Stack>
                 </StackItem>
                 <StackItem className={classes.eventViewerContainer}>
-                    <EventViewer appState={props.appState} />
+                    <EventViewer />
                 </StackItem>
             </div>
         </Stack>
     );
 });
-
-export interface IGameViewerProps {
-    appState: AppState;
-}
 
 interface IGameViewerClassNames {
     gameViewer: string;
@@ -60,7 +55,6 @@ const getClassNames = (gameLoaded: boolean): IGameViewerClassNames =>
             // Grid should be more resize friendly than flex if we ever do responsive design
             display: "grid",
             gridTemplateColumns: "3fr 1fr",
-            // height: "100%",
         },
         eventViewerContainer: {
             margin: "0 10px",

--- a/src/components/ModalDialogContainer.tsx
+++ b/src/components/ModalDialogContainer.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 
-import { AppState } from "src/state/AppState";
 import { AddPlayerDialog } from "./dialogs/AddPlayerDialog";
 import { NewGameDialog } from "./dialogs/NewGameDialog";
 import { ExportToSheetsDialog } from "./dialogs/ExportToSheetsDialog";
@@ -12,25 +11,20 @@ import { HelpDialog } from "./dialogs/HelpDialog";
 import { CustomizeGameFormatDialog } from "./dialogs/CustomizeGameFormatDialog";
 import { AddQuestionsDialog } from "./dialogs/AddQuestionsDialog";
 
-export const ModalDialogContainer = observer((props: IModalDialogContainerProps) => {
+export const ModalDialogContainer = observer(() => {
     // The Protest dialogs aren't here because they require extra information
-    const appState: AppState = props.appState;
 
     return (
         <>
-            <AddPlayerDialog appState={appState} />
-            <AddQuestionsDialog appState={appState} />
-            <CustomizeGameFormatDialog appState={appState} />
-            <ExportToJsonDialog appState={appState} />
-            <ExportToSheetsDialog appState={appState} />
-            <FontDialog appState={appState} />
-            <HelpDialog appState={appState} />
-            <ImportGameDialog appState={appState} />
-            <NewGameDialog appState={appState} />
+            <AddPlayerDialog />
+            <AddQuestionsDialog />
+            <CustomizeGameFormatDialog />
+            <ExportToJsonDialog />
+            <ExportToSheetsDialog />
+            <FontDialog />
+            <HelpDialog />
+            <ImportGameDialog />
+            <NewGameDialog />
         </>
     );
 });
-
-export interface IModalDialogContainerProps {
-    appState: AppState;
-}

--- a/src/components/ModaqControl.tsx
+++ b/src/components/ModaqControl.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+
+import { StateProvider } from "src/contexts/StateContext";
+import { AppState } from "src/state/AppState";
+import { GameViewer } from "./GameViewer";
+import { ModalDialogContainer } from "./ModalDialogContainer";
+
+export const ModaqControl = observer((props: IModaqControlProps) => {
+    return (
+        <StateProvider appState={props.appState}>
+            <div>
+                <GameViewer />
+                <ModalDialogContainer />
+            </div>
+        </StateProvider>
+    );
+});
+
+export interface IModaqControlProps {
+    appState: AppState;
+}

--- a/src/components/QuestionViewer.tsx
+++ b/src/components/QuestionViewer.tsx
@@ -8,6 +8,7 @@ import { BonusQuestion } from "./BonusQuestion";
 import { Cycle } from "src/state/Cycle";
 import { ISeparatorStyles, mergeStyleSets, Separator } from "@fluentui/react";
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
 const separatorStyles: Partial<ISeparatorStyles> = {
     root: {
@@ -15,11 +16,12 @@ const separatorStyles: Partial<ISeparatorStyles> = {
     },
 };
 
-export const QuestionViewer = observer((props: IQuestionViewerProps) => {
-    const fontSize: number = props.appState.uiState.questionFontSize;
+export const QuestionViewer = observer(() => {
+    const appState: AppState = React.useContext(StateContext);
+    const fontSize: number = appState.uiState.questionFontSize;
     const classes: IQuestionViewerClassNames = getClassNames(fontSize);
-    const game: GameState = props.appState.game;
-    const uiState: UIState = props.appState.uiState;
+    const game: GameState = appState.game;
+    const uiState: UIState = appState.uiState;
 
     const cycle: Cycle = game.playableCycles[uiState.cycleIndex];
     const tossupIndex: number = game.getTossupIndex(uiState.cycleIndex);
@@ -42,7 +44,7 @@ export const QuestionViewer = observer((props: IQuestionViewerProps) => {
     } else {
         bonus = (
             <BonusQuestion
-                appState={props.appState}
+                appState={appState}
                 bonus={game.packet.bonuses[bonusIndex]}
                 bonusIndex={bonusIndex}
                 cycle={cycle}
@@ -55,7 +57,7 @@ export const QuestionViewer = observer((props: IQuestionViewerProps) => {
     if (tossupIndex >= 0 && tossupIndex < game.packet.tossups.length) {
         tossup = (
             <TossupQuestion
-                appState={props.appState}
+                appState={appState}
                 bonusIndex={bonusIndex}
                 tossupNumber={tossupIndex + 1}
                 cycle={cycle}
@@ -84,10 +86,6 @@ export const QuestionViewer = observer((props: IQuestionViewerProps) => {
         </div>
     );
 });
-
-export interface IQuestionViewerProps {
-    appState: AppState;
-}
 
 interface IQuestionViewerClassNames {
     questionViewer: string;

--- a/src/components/QuestionViewerContainer.tsx
+++ b/src/components/QuestionViewerContainer.tsx
@@ -5,27 +5,25 @@ import { mergeStyleSets } from "@fluentui/react";
 import { CycleChooser } from "./CycleChooser";
 import { QuestionViewer } from "./QuestionViewer";
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
-export const QuestionViewerContainer = observer((props: IQuestionViewerContainerProps) => {
+export const QuestionViewerContainer = observer(() => {
+    const appState: AppState = React.useContext(StateContext);
     const classes: IQuestionViewerContainerClassNames = getClassNames();
 
-    if (!props.appState.game.isLoaded) {
+    if (!appState.game.isLoaded) {
         return null;
     }
 
     return (
         <div className="question-viewer-container">
             <div className={classes.cycleChooserContainer}>
-                <CycleChooser {...props} />
+                <CycleChooser />
             </div>
-            <QuestionViewer {...props} />
+            <QuestionViewer />
         </div>
     );
 });
-
-export interface IQuestionViewerContainerProps {
-    appState: AppState;
-}
 
 interface IQuestionViewerContainerClassNames {
     cycleChooserContainer: string;

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -3,19 +3,17 @@ import { Label, mergeStyleSets } from "@fluentui/react";
 import { observer } from "mobx-react-lite";
 
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
-export const Scoreboard = observer((props: IScoreboardProps) => {
+export const Scoreboard = observer(() => {
+    const appState: AppState = React.useContext(StateContext);
     const classes: IScoreboardStyle = getClassNames();
 
-    const scores: [number, number] = props.appState.game.finalScore;
-    const teamNames = props.appState.game.teamNames;
+    const scores: [number, number] = appState.game.finalScore;
+    const teamNames = appState.game.teamNames;
     const result = teamNames.length >= 2 ? `${teamNames[0]}: ${scores[0]}, ${teamNames[1]}: ${scores[1]}` : "";
     return <Label className={classes.board}>{result}</Label>;
 });
-
-export interface IScoreboardProps {
-    appState: AppState;
-}
 
 interface IScoreboardStyle {
     board: string;

--- a/src/components/dialogs/AddQuestionsDialog.tsx
+++ b/src/components/dialogs/AddQuestionsDialog.tsx
@@ -16,6 +16,7 @@ import { AppState } from "src/state/AppState";
 import { PacketLoader } from "../PacketLoader";
 import { PacketState } from "src/state/PacketState";
 import { AddQuestionDialogState } from "src/state/AddQuestionsDialogState";
+import { StateContext } from "src/contexts/StateContext";
 
 const content: IDialogContentProps = {
     type: DialogType.normal,
@@ -47,18 +48,19 @@ const modalProps: IModalProps = {
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const AddQuestionsDialog = observer(
-    (props: IAddQuestionsDialogPorps): JSX.Element => {
-        const submitHandler = React.useCallback(() => onSubmit(props), [props]);
-        const cancelHandler = React.useCallback(() => onCancel(props), [props]);
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
+        const submitHandler = React.useCallback(() => onSubmit(appState), [appState]);
+        const cancelHandler = React.useCallback(() => onCancel(appState), [appState]);
 
         return (
             <Dialog
-                hidden={props.appState.uiState.dialogState.addQuestions === undefined}
+                hidden={appState.uiState.dialogState.addQuestions === undefined}
                 dialogContentProps={content}
                 modalProps={modalProps}
                 onDismiss={cancelHandler}
             >
-                <AddQuestionsDialogBody {...props} />
+                <AddQuestionsDialogBody />
                 <DialogFooter>
                     <PrimaryButton text="Load" onClick={submitHandler} />
                     <DefaultButton text="Cancel" onClick={cancelHandler} />
@@ -69,19 +71,20 @@ export const AddQuestionsDialog = observer(
 );
 
 const AddQuestionsDialogBody = observer(
-    (props: IAddQuestionsDialogPorps): JSX.Element => {
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
         const loadHandler = React.useCallback(
-            (packet: PacketState) => props.appState.uiState.dialogState.addQuestions?.setPacket(packet),
-            [props]
+            (packet: PacketState) => appState.uiState.dialogState.addQuestions?.setPacket(packet),
+            [appState]
         );
 
-        return <PacketLoader appState={props.appState} onLoad={loadHandler} />;
+        return <PacketLoader appState={appState} onLoad={loadHandler} />;
     }
 );
 
-function onSubmit(props: IAddQuestionsDialogPorps): void {
-    const game: GameState = props.appState.game;
-    const state: AddQuestionDialogState | undefined = props.appState.uiState.dialogState.addQuestions;
+function onSubmit(appState: AppState): void {
+    const game: GameState = appState.game;
+    const state: AddQuestionDialogState | undefined = appState.uiState.dialogState.addQuestions;
     if (state == undefined) {
         throw new Error("Tried adding more questions without any questions");
     }
@@ -91,18 +94,14 @@ function onSubmit(props: IAddQuestionsDialogPorps): void {
     combinedPacket.setBonuses(game.packet.bonuses.concat(state.newPacket.bonuses));
     game.loadPacket(combinedPacket);
 
-    hideDialog(props);
+    hideDialog(appState);
 }
 
-function onCancel(props: IAddQuestionsDialogPorps): void {
-    props.appState.uiState.clearPacketStatus();
-    hideDialog(props);
+function onCancel(appState: AppState): void {
+    appState.uiState.clearPacketStatus();
+    hideDialog(appState);
 }
 
-function hideDialog(props: IAddQuestionsDialogPorps): void {
-    props.appState.uiState.dialogState.hideAddQuestionsDialog();
-}
-
-export interface IAddQuestionsDialogPorps {
-    appState: AppState;
+function hideDialog(appState: AppState): void {
+    appState.uiState.dialogState.hideAddQuestionsDialog();
 }

--- a/src/components/dialogs/CustomizeGameFormatDialog.tsx
+++ b/src/components/dialogs/CustomizeGameFormatDialog.tsx
@@ -23,6 +23,7 @@ import { GameState } from "src/state/GameState";
 import { AppState } from "src/state/AppState";
 import { IGameFormat, IPowerMarker } from "src/state/IGameFormat";
 import { CustomizeGameFormatDialogState } from "src/state/CustomizeGameFormatDialogState";
+import { StateContext } from "src/contexts/StateContext";
 
 const customFormatName = "Custom";
 
@@ -66,18 +67,19 @@ const sectionsStackTokens: Partial<IStackTokens> = { childrenGap: 20 };
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const CustomizeGameFormatDialog = observer(
-    (props: ICustomizeGameFormatDialogProps): JSX.Element => {
-        const submitHandler = React.useCallback(() => onSubmit(props), [props]);
-        const cancelHandler = React.useCallback(() => onCancel(props), [props]);
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
+        const submitHandler = React.useCallback(() => onSubmit(appState), [appState]);
+        const cancelHandler = React.useCallback(() => onCancel(appState), [appState]);
 
         return (
             <Dialog
-                hidden={props.appState.uiState.dialogState.customizeGameFormat === undefined}
+                hidden={appState.uiState.dialogState.customizeGameFormat === undefined}
                 dialogContentProps={content}
                 modalProps={modalProps}
                 onDismiss={cancelHandler}
             >
-                <CustomizeGameFormatDialogBody {...props} />
+                <CustomizeGameFormatDialogBody />
                 <DialogFooter>
                     <PrimaryButton text="Save" onClick={submitHandler} />
                     <DefaultButton text="Cancel" onClick={cancelHandler} />
@@ -88,9 +90,10 @@ export const CustomizeGameFormatDialog = observer(
 );
 
 const CustomizeGameFormatDialogBody = observer(
-    (props: ICustomizeGameFormatDialogProps): JSX.Element => {
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
         const customizeGameFormatState: CustomizeGameFormatDialogState | undefined =
-            props.appState.uiState.dialogState.customizeGameFormat;
+            appState.uiState.dialogState.customizeGameFormat;
 
         const regulationTossupCountChangeHandler = React.useCallback(
             (event: React.SyntheticEvent<HTMLElement, Event>, newValue?: string | undefined) => {
@@ -308,14 +311,14 @@ function getNumberOrUndefined(value: string | undefined): number | undefined {
     return isNaN(number) ? undefined : number;
 }
 
-function onSubmit(props: ICustomizeGameFormatDialogProps): void {
-    const game: GameState = props.appState.game;
-    const state: CustomizeGameFormatDialogState | undefined = props.appState.uiState.dialogState.customizeGameFormat;
+function onSubmit(appState: AppState): void {
+    const game: GameState = appState.game;
+    const state: CustomizeGameFormatDialogState | undefined = appState.uiState.dialogState.customizeGameFormat;
     if (state == undefined) {
         throw new Error("Tried customizing a game format with no game format");
     }
 
-    if (!isGameFormatValid(props)) {
+    if (!isGameFormatValid(appState)) {
         // We should already have the error repored, so just do nothing
         return;
     }
@@ -349,15 +352,15 @@ function onSubmit(props: ICustomizeGameFormatDialogProps): void {
 
     game.setGameFormat(updatedGameFormat);
 
-    hideDialog(props);
+    hideDialog(appState);
 }
 
 function sortPowersDescending(left: IPowerMarker, right: IPowerMarker): number {
     return right.points - left.points;
 }
 
-function isGameFormatValid(props: ICustomizeGameFormatDialogProps): boolean {
-    const state: CustomizeGameFormatDialogState | undefined = props.appState.uiState.dialogState.customizeGameFormat;
+function isGameFormatValid(appState: AppState): boolean {
+    const state: CustomizeGameFormatDialogState | undefined = appState.uiState.dialogState.customizeGameFormat;
     if (state == undefined) {
         throw new Error("Tried changing a format with no modified format");
     }
@@ -365,14 +368,10 @@ function isGameFormatValid(props: ICustomizeGameFormatDialogProps): boolean {
     return state.powerMarkerErrorMessage == undefined && state.powerValuesErrorMessage == undefined;
 }
 
-function onCancel(props: ICustomizeGameFormatDialogProps): void {
-    hideDialog(props);
+function onCancel(appState: AppState): void {
+    hideDialog(appState);
 }
 
-function hideDialog(props: ICustomizeGameFormatDialogProps): void {
-    props.appState.uiState.dialogState.hideCustomizeGameFormatDialog();
-}
-
-export interface ICustomizeGameFormatDialogProps {
-    appState: AppState;
+function hideDialog(appState: AppState): void {
+    appState.uiState.dialogState.hideCustomizeGameFormatDialog();
 }

--- a/src/components/dialogs/ExportToJsonDialog.tsx
+++ b/src/components/dialogs/ExportToJsonDialog.tsx
@@ -15,6 +15,7 @@ import {
 import * as QBJ from "src/qbj/QBJ";
 import { AppState } from "src/state/AppState";
 import { GameState } from "src/state/GameState";
+import { StateContext } from "src/contexts/StateContext";
 
 const content: IDialogContentProps = {
     type: DialogType.normal,
@@ -45,10 +46,11 @@ const modalProps: IModalProps = {
 };
 
 export const ExportToJsonDialog = observer(
-    (props: IExportToJsonDialogProps): JSX.Element => {
-        const game: GameState = props.appState.game;
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
+        const game: GameState = appState.game;
 
-        const closeHandler = React.useCallback(() => hideDialog(props), [props]);
+        const closeHandler = React.useCallback(() => hideDialog(appState), [appState]);
 
         const joinedTeamNames: string = game.teamNames.join("_");
 
@@ -66,7 +68,7 @@ export const ExportToJsonDialog = observer(
 
         return (
             <Dialog
-                hidden={!props.appState.uiState.dialogState.exportToJsonDialogVisible}
+                hidden={!appState.uiState.dialogState.exportToJsonDialogVisible}
                 dialogContentProps={content}
                 modalProps={modalProps}
                 maxWidth="40vw"
@@ -90,10 +92,6 @@ export const ExportToJsonDialog = observer(
     }
 );
 
-function hideDialog(props: IExportToJsonDialogProps) {
-    props.appState.uiState.dialogState.hideExportToJsonDialog();
-}
-
-export interface IExportToJsonDialogProps {
-    appState: AppState;
+function hideDialog(appState: AppState) {
+    appState.uiState.dialogState.hideExportToJsonDialog();
 }

--- a/src/components/dialogs/FontDialog.tsx
+++ b/src/components/dialogs/FontDialog.tsx
@@ -12,6 +12,7 @@ import {
     SpinButton,
 } from "@fluentui/react";
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
 const content: IDialogContentProps = {
     type: DialogType.normal,
@@ -45,19 +46,20 @@ const minimumFontSize = 12;
 const maximumFontSize = 40;
 
 export const FontDialog = observer(
-    (props: IFontDialogProps): JSX.Element => {
-        const closeHandler = React.useCallback(() => hideDialog(props), [props]);
-        const submitHandler = React.useCallback(() => updateFont(props), [props]);
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
+        const closeHandler = React.useCallback(() => hideDialog(appState), [appState]);
+        const submitHandler = React.useCallback(() => updateFont(appState), [appState]);
 
         return (
             <Dialog
-                hidden={props.appState.uiState.pendingQuestionFontSize == undefined}
+                hidden={appState.uiState.pendingQuestionFontSize == undefined}
                 dialogContentProps={content}
                 modalProps={modalProps}
                 maxWidth="40vw"
                 onDismiss={closeHandler}
             >
-                <FontDialogBody {...props} />
+                <FontDialogBody />
                 <DialogFooter>
                     <PrimaryButton text="OK" onClick={submitHandler} />
                     <DefaultButton text="Cancel" onClick={closeHandler} />
@@ -68,7 +70,8 @@ export const FontDialog = observer(
 );
 
 const FontDialogBody = observer(
-    (props: IFontDialogProps): JSX.Element => {
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
         const changeHandler = React.useCallback(
             (event: React.SyntheticEvent<HTMLElement, Event>, newValue?: string | undefined) => {
                 if (newValue == undefined) {
@@ -77,14 +80,14 @@ const FontDialogBody = observer(
 
                 const size = Number.parseInt(newValue, 10);
                 if (!isNaN(size)) {
-                    props.appState.uiState.setPendingQuestionFontSize(size);
+                    appState.uiState.setPendingQuestionFontSize(size);
                 }
             },
-            [props]
+            [appState]
         );
 
         const value: string = (
-            props.appState.uiState.pendingQuestionFontSize ?? props.appState.uiState.questionFontSize
+            appState.uiState.pendingQuestionFontSize ?? appState.uiState.questionFontSize
         ).toString();
 
         return (
@@ -102,15 +105,11 @@ const FontDialogBody = observer(
     }
 );
 
-function updateFont(props: IFontDialogProps): void {
-    props.appState.uiState.setQuestionFontSize(props.appState.uiState.pendingQuestionFontSize ?? minimumFontSize);
-    hideDialog(props);
+function updateFont(appState: AppState): void {
+    appState.uiState.setQuestionFontSize(appState.uiState.pendingQuestionFontSize ?? minimumFontSize);
+    hideDialog(appState);
 }
 
-function hideDialog(props: IFontDialogProps): void {
-    props.appState.uiState.resetPendingQuestionFontSize();
-}
-
-export interface IFontDialogProps {
-    appState: AppState;
+function hideDialog(appState: AppState): void {
+    appState.uiState.resetPendingQuestionFontSize();
 }

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -14,6 +14,7 @@ import {
     StackItem,
 } from "@fluentui/react";
 import { AppState } from "src/state/AppState";
+import { StateContext } from "src/contexts/StateContext";
 
 declare const __BUILD_VERSION__: string;
 
@@ -46,12 +47,13 @@ const modalProps: IModalProps = {
 };
 
 export const HelpDialog = observer(
-    (props: IHelpDialogPorps): JSX.Element => {
-        const closeHandler = React.useCallback(() => hideDialog(props), [props]);
+    (): JSX.Element => {
+        const appState: AppState = React.useContext(StateContext);
+        const closeHandler = React.useCallback(() => hideDialog(appState), [appState]);
 
         return (
             <Dialog
-                hidden={!props.appState.uiState.dialogState.helpDialogVisible}
+                hidden={!appState.uiState.dialogState.helpDialogVisible}
                 dialogContentProps={content}
                 modalProps={modalProps}
                 maxWidth="30vw"
@@ -85,10 +87,6 @@ const HelpDialogBody = observer(
     }
 );
 
-function hideDialog(props: IHelpDialogPorps): void {
-    props.appState.uiState.dialogState.hideHelpDialog();
-}
-
-export interface IHelpDialogPorps {
-    appState: AppState;
+function hideDialog(appState: AppState): void {
+    appState.uiState.dialogState.hideHelpDialog();
 }

--- a/src/contexts/StateContext.tsx
+++ b/src/contexts/StateContext.tsx
@@ -1,0 +1,12 @@
+import React, { ReactElement } from "react";
+import { AppState } from "src/state/AppState";
+
+export const StateContext = React.createContext<AppState>(new AppState());
+
+export function StateProvider(props: React.PropsWithChildren<IStateProviderProps>): ReactElement {
+    return <StateContext.Provider value={props.appState}>{props.children}</StateContext.Provider>;
+}
+
+export interface IStateProviderProps {
+    appState: AppState;
+}

--- a/src/controllers/AddPlayerDialogController.ts
+++ b/src/controllers/AddPlayerDialogController.ts
@@ -1,0 +1,51 @@
+import * as NewGameValidator from "src/state/NewGameValidator";
+import { AppState } from "src/state/AppState";
+import { GameState } from "src/state/GameState";
+import { Player } from "src/state/TeamState";
+import { UIState } from "src/state/UIState";
+
+// TODO: Consider making AppState something we can get from a single instance (AppState.instance? AppServices.getAppState)
+// This would be a type of dependency injection.
+// We already get appState in most contexts from React.useContext. We shouldn't use that here, to avoid an explicit
+// React dependency.
+
+export function addPlayer(appState: AppState): void {
+    const game: GameState = appState.game;
+    const uiState: UIState = appState.uiState;
+
+    if (validatePlayer(appState) != undefined) {
+        return;
+    }
+
+    const newPlayer: Player | undefined = uiState.pendingNewPlayer;
+    if (newPlayer == undefined) {
+        throw new Error("Tried adding a player with no new player");
+    }
+
+    game.addPlayer(newPlayer);
+
+    // TODO: Only do this if the number of active players is less than the maximum number of active players
+    game.cycles[uiState.cycleIndex].addPlayerJoins(newPlayer);
+
+    hideDialog(appState);
+}
+
+export function validatePlayer(appState: AppState): string | undefined {
+    const newPlayer: Player | undefined = appState.uiState.pendingNewPlayer;
+    if (newPlayer == undefined) {
+        throw new Error("Tried adding a player with no new player");
+    }
+
+    // Trim the player name on submit, so the user can type in spaces while creating the name in the UI
+    const trimmedPlayerName: string = newPlayer.name.trim();
+    if (trimmedPlayerName.length === 0) {
+        return "Player name cannot be blank";
+    }
+
+    const playersOnTeam: Player[] = [...appState.game.getPlayers(newPlayer.teamName), newPlayer];
+    return NewGameValidator.newPlayerNameUnique(playersOnTeam, trimmedPlayerName);
+}
+
+export function hideDialog(appState: AppState): void {
+    appState.uiState.resetPendingNewPlayer();
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,25 +16,10 @@ import {
 } from "@fluentui/react";
 import { initializeIcons } from "@fluentui/react/lib/Icons";
 import { configure } from "mobx";
-import { observer } from "mobx-react-lite";
 import { AsyncTrunk } from "mobx-sync";
 
-import { GameViewer } from "./components/GameViewer";
 import { AppState } from "./state/AppState";
-import { ModalDialogContainer } from "./components/ModalDialogContainer";
-
-const Root = observer((props: IRootProps) => {
-    return (
-        <div>
-            <GameViewer appState={props.appState} />
-            <ModalDialogContainer appState={props.appState} />
-        </div>
-    );
-});
-
-interface IRootProps {
-    appState: AppState;
-}
+import { ModaqControl } from "./components/ModaqControl";
 
 // TODO: Move to a separate file in Component?
 class ErrorBoundary extends React.Component<IErrorBoundaryProps, IErrorBoundaryState> {
@@ -155,7 +140,7 @@ if (element) {
     trunk.init(appState).then(() => {
         ReactDOM.render(
             <ErrorBoundary appState={appState}>
-                <Root appState={appState} />
+                <ModaqControl appState={appState} />
             </ErrorBoundary>,
             document.getElementById("root")
         );

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -256,7 +256,6 @@ export class GameState {
         this.packet = packet;
 
         if (this.cycles.length < this.packet.tossups.length) {
-            // TODO: Don't create cycles for tiebreaker rounds once we create packet formats to specify limits
             for (let i = this.cycles.length; i < this.packet.tossups.length; i++) {
                 this.cycles.push(new Cycle());
             }


### PR DESCRIPTION
No real functional changes, but some code organizational ones
- Use React.useContext where appropriate to get the AppState instance. This lets us remove lots of component props that just took in AppState (#80)
- Move the Root component to a separate public component, so future work to make MODAQ embeddable is easier (begin #81)
- Begin moving AddPlayerDialog to use a controller pattern for event handling (begin #56)