### PR TITLE
Merged PR 203: 0.1.5 - Support difficulty modifiers, underline-only, …

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import * as gameFormats from "src/state/GameFormats";
 import { IGameFormat as gameFormat } from "src/state/IGameFormat";
 import { IBonus as bonus, IPacket as packet, ITossup as tossup } from "src/state/IPacket";
 import { IPlayer as player } from "src/state/TeamState";
@@ -16,3 +17,5 @@ export type IBonus = bonus;
 export type IPlayer = player;
 
 export type IGameFormat = gameFormat;
+
+export const GameFormats = gameFormats;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/BonusQuestionPart.tsx
+++ b/src/components/BonusQuestionPart.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Dropdown, IDropdownOption, IDropdownStyles, mergeStyleSets } 
 import { observer } from "mobx-react-lite";
 
 import * as FormattedTextParser from "src/parser/FormattedTextParser";
-import { IBonusPart } from "src/state/PacketState";
+import { BonusPart } from "src/state/PacketState";
 import { Cycle } from "src/state/Cycle";
 import { Answer } from "./Answer";
 import { FormattedText } from "./FormattedText";
@@ -74,7 +74,8 @@ export const BonusQuestionPart = observer((props: IBonusQuestionPartProps) => {
             <div className={classes.bonusPartQuestionText}>
                 {correctnessMarker}
                 <span>
-                    [{props.bonusPart.value}] <FormattedText segments={bonusPartText} />
+                    [{props.bonusPart.value}
+                    {props.bonusPart.difficultyModifier}] <FormattedText segments={bonusPartText} />
                 </span>
             </div>
             <div className={classes.bonusPartAnswerSpacer}>
@@ -119,7 +120,7 @@ function onTeamAnswerChange(
 
 // TODO: See if it makes sense to move disabled to UIState
 export interface IBonusQuestionPartProps {
-    bonusPart: IBonusPart;
+    bonusPart: BonusPart;
     cycle: Cycle;
     disabled: boolean;
     gameFormat: IGameFormat;

--- a/src/components/FormattedText.tsx
+++ b/src/components/FormattedText.tsx
@@ -29,6 +29,11 @@ const FormattedSegment = observer((props: IFormattedSegmentProps) => {
         element = <i>{element}</i>;
     }
 
+    if (props.segment.underlined) {
+        element = <u>{element}</u>;
+    }
+
+    // Obsolete, but here for back-compat with YAPP versions before 0.2.4
     if (props.segment.required) {
         element = (
             <u>

--- a/src/controllers/PacketLoaderController.ts
+++ b/src/controllers/PacketLoaderController.ts
@@ -1,12 +1,11 @@
 import { AppState } from "src/state/AppState";
 import { IPacket } from "src/state/IPacket";
-import { Bonus, IBonusPart, PacketState, Tossup } from "src/state/PacketState";
+import { Bonus, BonusPart, PacketState, Tossup } from "src/state/PacketState";
 import { UIState } from "src/state/UIState";
 
-export function loadPacket(appState: AppState, parsedPacket: IPacket): PacketState | undefined
-{
+export function loadPacket(appState: AppState, parsedPacket: IPacket): PacketState | undefined {
     const uiState: UIState = appState.uiState;
-    
+
     if (parsedPacket.tossups == undefined) {
         uiState.setPacketStatus({
             isError: true,
@@ -29,12 +28,13 @@ export function loadPacket(appState: AppState, parsedPacket: IPacket): PacketSta
                 throw errorMessage;
             }
 
-            const parts: IBonusPart[] = [];
+            const parts: BonusPart[] = [];
             for (let i = 0; i < bonus.answers.length; i++) {
                 parts.push({
                     answer: bonus.answers[i],
                     question: bonus.parts[i],
                     value: bonus.values[i],
+                    difficultyModifier: bonus.difficultyModifiers ? bonus.difficultyModifiers[i] : undefined,
                 });
             }
 

--- a/src/parser/FormattedTextParser.ts
+++ b/src/parser/FormattedTextParser.ts
@@ -9,12 +9,12 @@ export function parseFormattedText(text: string): IFormattedText[] {
 
     let bolded = false;
     let emphasized = false;
-    let required = false;
+    let underlined = false;
     let startIndex = 0;
 
     // If we need to support older browswers, use RegExp, exec, and a while loop. See
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
-    const matchIterator: IterableIterator<RegExpMatchArray> = text.matchAll(/<\/?em>|<\/?req>|<\/?b>/gi);
+    const matchIterator: IterableIterator<RegExpMatchArray> = text.matchAll(/<\/?em>|<\/?req>|<\/?b>|<\/?u>/gi);
 
     for (const match of matchIterator) {
         const slice: string = text.substring(startIndex, match.index);
@@ -23,7 +23,7 @@ export function parseFormattedText(text: string): IFormattedText[] {
                 text: text.substring(startIndex, match.index),
                 bolded,
                 emphasized,
-                required,
+                underlined,
             };
             result.push(formattedSlice);
         }
@@ -38,16 +38,24 @@ export function parseFormattedText(text: string): IFormattedText[] {
                 emphasized = false;
                 break;
             case "<req>":
-                required = true;
+                bolded = true;
+                underlined = true;
                 break;
             case "</req>":
-                required = false;
+                bolded = false;
+                underlined = false;
                 break;
             case "<b>":
                 bolded = true;
                 break;
             case "</b>":
                 bolded = false;
+                break;
+            case "<u>":
+                underlined = true;
+                break;
+            case "</u>":
+                underlined = false;
                 break;
             default:
                 throw `Unknown match: ${tag}`;
@@ -62,7 +70,7 @@ export function parseFormattedText(text: string): IFormattedText[] {
             text: text.substring(startIndex),
             bolded,
             emphasized,
-            required,
+            underlined,
         });
     }
 
@@ -102,7 +110,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
                 text: firstWord,
                 bolded: value.bolded,
                 emphasized: value.emphasized,
-                required: value.required,
+                underlined: value.underlined,
             });
             splitFormattedText.push(previousWord);
         }
@@ -118,7 +126,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
                     text: word,
                     bolded: value.bolded,
                     emphasized: value.emphasized,
-                    required: value.required,
+                    underlined: value.underlined,
                 };
                 splitFormattedText.push([formattedWord]);
             }
@@ -130,7 +138,7 @@ export function splitFormattedTextIntoWords(text: string): IFormattedText[][] {
                 text: lastSegment,
                 bolded: value.bolded,
                 emphasized: value.emphasized,
-                required: value.required,
+                underlined: value.underlined,
             });
         }
     }

--- a/src/parser/IFormattedText.ts
+++ b/src/parser/IFormattedText.ts
@@ -2,5 +2,6 @@ export interface IFormattedText {
     text: string;
     bolded: boolean;
     emphasized: boolean;
-    required: boolean;
+    required?: boolean;
+    underlined?: boolean;
 }

--- a/src/state/IPacket.ts
+++ b/src/state/IPacket.ts
@@ -15,4 +15,5 @@ export interface IBonus {
     answers: string[];
     number: number;
     values: number[];
+    difficultyModifiers?: string[];
 }

--- a/src/state/PacketState.ts
+++ b/src/state/PacketState.ts
@@ -37,16 +37,11 @@ export interface IQuestion {
     answer: string;
 }
 
-export class IBonusPart implements IQuestion {
-    public question: string;
-    public answer: string;
-    public value: number;
-
-    constructor(question: string, answer: string, value = 10) {
-        this.question = question;
-        this.answer = answer;
-        this.value = value;
-    }
+export interface BonusPart {
+    question: string;
+    answer: string;
+    value: number;
+    difficultyModifier?: string;
 }
 
 export class Tossup implements IQuestion {
@@ -128,9 +123,9 @@ export class Tossup implements IQuestion {
 export class Bonus {
     public leadin: string;
 
-    public parts: IBonusPart[];
+    public parts: BonusPart[];
 
-    constructor(leadin: string, parts: IBonusPart[]) {
+    constructor(leadin: string, parts: BonusPart[]) {
         // We don't use makeAutoObservable because leadin doesn't need to be observable (never changes)
         makeObservable(this, {
             parts: observable,

--- a/tests/FormattedTextParserTests.ts
+++ b/tests/FormattedTextParserTests.ts
@@ -13,7 +13,7 @@ describe("FormattedTextParserTests", () => {
                     text,
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
             ]);
         });
@@ -26,7 +26,7 @@ describe("FormattedTextParserTests", () => {
                     text: expectedText,
                     bolded: false,
                     emphasized: true,
-                    required: false,
+                    underlined: false,
                 },
             ]);
         });
@@ -37,9 +37,35 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal([
                 {
                     text: expectedText,
+                    bolded: true,
+                    emphasized: false,
+                    underlined: true,
+                },
+            ]);
+        });
+        it("All bolded", () => {
+            const expectedText = "This text is all bolded.";
+            const textToFormat = `<b>${expectedText}</b>`;
+            const result: IFormattedText[] = FormattedTextParser.parseFormattedText(textToFormat);
+            expect(result).to.deep.equal([
+                {
+                    text: expectedText,
+                    bolded: true,
+                    emphasized: false,
+                    underlined: false,
+                },
+            ]);
+        });
+        it("All underlined", () => {
+            const expectedText = "This text is all underlined.";
+            const textToFormat = `<u>${expectedText}</u>`;
+            const result: IFormattedText[] = FormattedTextParser.parseFormattedText(textToFormat);
+            expect(result).to.deep.equal([
+                {
+                    text: expectedText,
                     bolded: false,
                     emphasized: false,
-                    required: true,
+                    underlined: true,
                 },
             ]);
         });
@@ -51,31 +77,31 @@ describe("FormattedTextParserTests", () => {
                     text: "Before ",
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
                 {
                     text: "emphasized then",
                     bolded: false,
                     emphasized: true,
-                    required: false,
+                    underlined: false,
                 },
                 {
                     text: " in between ",
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
                 {
                     text: "required then",
-                    bolded: false,
+                    bolded: true,
                     emphasized: false,
-                    required: true,
+                    underlined: true,
                 },
                 {
                     text: " done.",
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
             ]);
         });
@@ -87,25 +113,25 @@ describe("FormattedTextParserTests", () => {
                     text: "The epic ",
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
                 {
                     text: "The ",
                     bolded: false,
                     emphasized: true,
-                    required: false,
+                    underlined: false,
                 },
                 {
                     text: "Iliad",
-                    bolded: false,
+                    bolded: true,
                     emphasized: true,
-                    required: true,
+                    underlined: true,
                 },
                 {
                     text: " is by Homer",
                     bolded: false,
                     emphasized: false,
-                    required: false,
+                    underlined: false,
                 },
             ]);
         });
@@ -120,7 +146,7 @@ describe("FormattedTextParserTests", () => {
                         text: word,
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ];
             });
@@ -137,7 +163,7 @@ describe("FormattedTextParserTests", () => {
                         text: word,
                         bolded: true,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ];
             });
@@ -154,7 +180,24 @@ describe("FormattedTextParserTests", () => {
                         text: word,
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
+                    },
+                ];
+            });
+
+            expect(result).to.deep.equal(expected);
+        });
+        it("All underlined", () => {
+            const expectedText = "This text is all bolded.";
+            const textToFormat = `<u>${expectedText}</u>`;
+            const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(textToFormat);
+            const expected: IFormattedText[][] = expectedText.split(/\s+/g).map((word) => {
+                return [
+                    {
+                        text: word,
+                        bolded: false,
+                        emphasized: false,
+                        underlined: true,
                     },
                 ];
             });
@@ -169,9 +212,9 @@ describe("FormattedTextParserTests", () => {
                 return [
                     {
                         text: word,
-                        bolded: false,
+                        bolded: true,
                         emphasized: false,
-                        required: true,
+                        underlined: true,
                     },
                 ];
             });
@@ -187,7 +230,7 @@ describe("FormattedTextParserTests", () => {
                         text: "Before",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -195,7 +238,7 @@ describe("FormattedTextParserTests", () => {
                         text: "emphasized",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -203,7 +246,7 @@ describe("FormattedTextParserTests", () => {
                         text: "then",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -211,7 +254,7 @@ describe("FormattedTextParserTests", () => {
                         text: "in",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -219,23 +262,23 @@ describe("FormattedTextParserTests", () => {
                         text: "between",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
                     {
                         text: "required",
-                        bolded: false,
+                        bolded: true,
                         emphasized: false,
-                        required: true,
+                        underlined: true,
                     },
                 ],
                 [
                     {
                         text: "then",
-                        bolded: false,
+                        bolded: true,
                         emphasized: false,
-                        required: true,
+                        underlined: true,
                     },
                 ],
                 [
@@ -243,12 +286,12 @@ describe("FormattedTextParserTests", () => {
                         text: "done.",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
             ]);
         });
-        it("Overlap", () => {
+        it("Overlap (req)", () => {
             const text = "The epic <em>The <req>Iliad</req></em> is by Homer";
             const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(text);
             expect(result).to.deep.equal([
@@ -257,7 +300,7 @@ describe("FormattedTextParserTests", () => {
                         text: "The",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -265,7 +308,7 @@ describe("FormattedTextParserTests", () => {
                         text: "epic",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -273,15 +316,15 @@ describe("FormattedTextParserTests", () => {
                         text: "The",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
                     {
                         text: "Iliad",
-                        bolded: false,
+                        bolded: true,
                         emphasized: true,
-                        required: true,
+                        underlined: true,
                     },
                 ],
                 [
@@ -289,7 +332,7 @@ describe("FormattedTextParserTests", () => {
                         text: "is",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -297,7 +340,7 @@ describe("FormattedTextParserTests", () => {
                         text: "by",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -305,7 +348,69 @@ describe("FormattedTextParserTests", () => {
                         text: "Homer",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
+                    },
+                ],
+            ]);
+        });
+        it("Overlap (bold + underline)", () => {
+            const text = "The epic <em>The <u><b>Iliad</b></u></em> is by Homer";
+            const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(text);
+            expect(result).to.deep.equal([
+                [
+                    {
+                        text: "The",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
+                    },
+                ],
+                [
+                    {
+                        text: "epic",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
+                    },
+                ],
+                [
+                    {
+                        text: "The",
+                        bolded: false,
+                        emphasized: true,
+                        underlined: false,
+                    },
+                ],
+                [
+                    {
+                        text: "Iliad",
+                        bolded: true,
+                        emphasized: true,
+                        underlined: true,
+                    },
+                ],
+                [
+                    {
+                        text: "is",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
+                    },
+                ],
+                [
+                    {
+                        text: "by",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
+                    },
+                ],
+                [
+                    {
+                        text: "Homer",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
                     },
                 ],
             ]);
@@ -319,7 +424,7 @@ describe("FormattedTextParserTests", () => {
                         text: "My",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -327,7 +432,7 @@ describe("FormattedTextParserTests", () => {
                         text: "book",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -335,13 +440,13 @@ describe("FormattedTextParserTests", () => {
                         text: "title",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                     {
                         text: ",",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -349,7 +454,7 @@ describe("FormattedTextParserTests", () => {
                         text: "written",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -357,7 +462,7 @@ describe("FormattedTextParserTests", () => {
                         text: "by",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
                 [
@@ -365,13 +470,13 @@ describe("FormattedTextParserTests", () => {
                         text: "me.",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                 ],
             ]);
         });
         it("One word with formatting", () => {
-            const text = "Plain<req>required</req>dull<em>emphasized</em><b>bolded</b>boring";
+            const text = "Plain<req>required</req>dull<em>emphasized</em><b>bolded</b>boring<u>underlined</u>word";
             const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(text);
             expect(result).to.deep.equal([
                 [
@@ -379,37 +484,49 @@ describe("FormattedTextParserTests", () => {
                         text: "Plain",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                     {
                         text: "required",
-                        bolded: false,
+                        bolded: true,
                         emphasized: false,
-                        required: true,
+                        underlined: true,
                     },
                     {
                         text: "dull",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                     {
                         text: "emphasized",
                         bolded: false,
                         emphasized: true,
-                        required: false,
+                        underlined: false,
                     },
                     {
                         text: "bolded",
                         bolded: true,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
                     },
                     {
                         text: "boring",
                         bolded: false,
                         emphasized: false,
-                        required: false,
+                        underlined: false,
+                    },
+                    {
+                        text: "underlined",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: true,
+                    },
+                    {
+                        text: "word",
+                        bolded: false,
+                        emphasized: false,
+                        underlined: false,
                     },
                 ],
             ]);

--- a/tests/PacketStateTossupTests.ts
+++ b/tests/PacketStateTossupTests.ts
@@ -41,7 +41,7 @@ describe("PacketStateTossupTests", () => {
             expect(formattedWord.text).to.equal("This");
             expect(formattedWord.bolded).to.be.true;
             expect(formattedWord.emphasized).to.be.false;
-            expect(formattedWord.required).to.be.false;
+            expect(formattedWord.underlined).to.be.false;
         });
     });
 


### PR DESCRIPTION
…and export GameFormats

- Support difficulty modifiers in bonus parts, e.g. [10e] (#94)
- Support underline-only formatting, so they show up for prompts
- Export GameFormats in index.tsx so it's easier to specify an IGameFormat (#95)
- Bump version to 0.1.5