### PR TITLE
1.0.0 - Bugfixes, Customize Format redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "0.2.3",
+    "version": "1.0.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/CycleChooser.tsx
+++ b/src/components/CycleChooser.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { DefaultButton, IButtonStyles } from "@fluentui/react/lib/Button";
 import { TextField, ITextFieldStyles } from "@fluentui/react/lib/TextField";
+import { useId } from "@fluentui/react-hooks";
 
 import { UIState } from "src/state/UIState";
 import { AppState } from "src/state/AppState";
-import { ILabelStyles, Label } from "@fluentui/react";
+import { ILabelStyles, Label, TooltipHost } from "@fluentui/react";
 import { StateContext } from "src/contexts/StateContext";
 
 const ReturnKeyCode = 13;
@@ -50,22 +51,39 @@ export const CycleChooser = observer(() => {
 
     const uiState: UIState = appState.uiState;
 
+    const previousButtonTooltipId: string = useId();
     const previousButton: JSX.Element = (
-        <DefaultButton
-            key="previousButton"
-            onClick={onPreviousClickHandler}
-            disabled={uiState.cycleIndex === 0}
-            styles={previousButtonStyle}
+        <TooltipHost
+            aria-describedby={previousButtonTooltipId}
+            content="Previous (Shift+P)"
+            id={previousButtonTooltipId}
         >
-            &larr; Previous
-        </DefaultButton>
+            <DefaultButton
+                key="previousButton"
+                onClick={onPreviousClickHandler}
+                disabled={uiState.cycleIndex === 0}
+                styles={previousButtonStyle}
+            >
+                &larr; Previous
+            </DefaultButton>
+        </TooltipHost>
     );
 
-    const nextButtonText: string = shouldNextButtonExport(appState) ? "Export..." : "Next →";
+    const doesNextButtonExport: boolean = shouldNextButtonExport(appState);
+    const nextButtonText: string = doesNextButtonExport ? "Export..." : "Next →";
+    const nextButtonTooltip: string = doesNextButtonExport ? "Export" : "Next (Shift+N)";
+    const nextButtonTooltipId: string = useId();
     const nextButton: JSX.Element = (
-        <DefaultButton key="nextButton" onClick={onNextClickHandler} styles={nextButtonStyle}>
-            {nextButtonText}
-        </DefaultButton>
+        <TooltipHost content={nextButtonTooltip} id={nextButtonTooltipId}>
+            <DefaultButton
+                aria-describedby={nextButtonTooltipId}
+                key="nextButton"
+                onClick={onNextClickHandler}
+                styles={nextButtonStyle}
+            >
+                {nextButtonText}
+            </DefaultButton>
+        </TooltipHost>
     );
 
     const questionNumber: number = uiState.cycleIndex + 1;

--- a/src/components/dialogs/AddPlayerDialogController.ts
+++ b/src/components/dialogs/AddPlayerDialogController.ts
@@ -35,7 +35,7 @@ export function changePlayerName(appState: AppState, newName: string): void {
 }
 
 export function changeTeamName(appState: AppState, teamName: string): void {
-    appState.uiState.updatePendingNewPlayerName(teamName);
+    appState.uiState.updatePendingNewPlayerTeamName(teamName);
 }
 
 export function validatePlayer(appState: AppState): string | undefined {
@@ -48,6 +48,10 @@ export function validatePlayer(appState: AppState): string | undefined {
     const trimmedPlayerName: string = newPlayer.name.trim();
     if (trimmedPlayerName.length === 0) {
         return "Player name cannot be blank";
+    }
+
+    if (appState.game.teamNames.indexOf(newPlayer.teamName) === -1) {
+        return "Team doesn't exist";
     }
 
     const playersOnTeam: Player[] = [...appState.game.getPlayers(newPlayer.teamName), newPlayer];

--- a/src/components/dialogs/CustomGameFormatDialogController.ts
+++ b/src/components/dialogs/CustomGameFormatDialogController.ts
@@ -1,0 +1,225 @@
+import { AppState } from "src/state/AppState";
+import { CustomizeGameFormatDialogState } from "src/state/CustomizeGameFormatDialogState";
+import { GameState } from "src/state/GameState";
+import { IGameFormat, IPowerMarker } from "src/state/IGameFormat";
+
+const customFormatName = "Custom";
+
+export function cancel(appState: AppState): void {
+    hideDialog(appState);
+}
+
+export function submit(appState: AppState): void {
+    const game: GameState = appState.game;
+    const state: CustomizeGameFormatDialogState | undefined = appState.uiState.dialogState.customizeGameFormat;
+    if (state == undefined) {
+        throw new Error("Tried customizing a game format with no game format");
+    }
+
+    if (!isGameFormatValid(appState)) {
+        // We should already have the error repored, so just do nothing
+        return;
+    }
+
+    const updatedGameFormat: IGameFormat = state.gameFormat;
+    if (updatedGameFormat.displayName !== customFormatName) {
+        // TS will complain about implicit any if we use Object.keys to do a deep comparison, so cast the objects as any,
+        // and then do a deep comparison
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyUpdatedGameFormat: any = updatedGameFormat as any;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyExistingGameFormat: any = game.gameFormat as any;
+
+        for (const key of Object.keys(updatedGameFormat)) {
+            if (anyUpdatedGameFormat[key] !== anyExistingGameFormat[key]) {
+                updatedGameFormat.displayName = customFormatName;
+                break;
+            }
+        }
+    }
+
+    // Power values should be in descending order, so sort them before saving the game format
+    const powers: IPowerMarker[] = [];
+    const powerValues: number[] = state.powerValues.split(",").map((value) => parseInt(value, 10));
+    for (let i = 0; i < state.powerMarkers.length; i++) {
+        powers.push({ marker: state.powerMarkers[i], points: powerValues[i] });
+    }
+
+    powers.sort(sortPowersDescending);
+    updatedGameFormat.powers = powers;
+
+    if (state.pronunicationGuideMarkers == undefined || state.pronunicationGuideMarkers.length === 0) {
+        updatedGameFormat.pronunciationGuideMarkers = undefined;
+    } else if (
+        state.pronunicationGuideMarkers.length === 2 &&
+        state.pronunicationGuideMarkers.every((value) => value.length > 0)
+    ) {
+        updatedGameFormat.pronunciationGuideMarkers = [
+            state.pronunicationGuideMarkers[0],
+            state.pronunicationGuideMarkers[1],
+        ];
+    }
+
+    game.setGameFormat(updatedGameFormat);
+
+    hideDialog(appState);
+}
+
+export function changeRegulationTossupCount(appState: AppState, newValue?: string | undefined): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    const count: number | undefined = getNumberOrUndefined(newValue);
+    if (count != undefined) {
+        customizeGameFormatState.updateGameFormat({ regulationTossupCount: count });
+    }
+}
+
+export function changeNegValue(appState: AppState, newValue?: string | undefined): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    const negValue: number | undefined = getNumberOrUndefined(newValue);
+    if (negValue != undefined) {
+        customizeGameFormatState.updateGameFormat({ negValue });
+    }
+}
+
+export function changePowerMarkers(appState: AppState, newValue?: string): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    if (newValue == undefined) {
+        return;
+    } else if (newValue.trim() === "") {
+        customizeGameFormatState.setPowerMarkers([]);
+        return;
+    }
+
+    // TODO: Handle power markers with commas, which would require handling escapes
+    const powerMarkers: string[] = newValue.split(",").map((value) => value.trim());
+    customizeGameFormatState.setPowerMarkers(powerMarkers);
+}
+
+export function changePowerValues(appState: AppState, newValue?: string): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    if (newValue == undefined) {
+        return;
+    }
+
+    customizeGameFormatState.setPowerValues(newValue);
+}
+
+export function changePronunciationGuideMarkers(appState: AppState, newValue?: string): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    if (newValue == undefined || newValue.trim() === "") {
+        customizeGameFormatState.setPronunciationGuideMarkers([]);
+        return;
+    }
+
+    const guides: string[] = newValue.split(",");
+    customizeGameFormatState.setPronunciationGuideMarkers(guides);
+}
+
+export function changeMinimumQuestionsInOvertime(appState: AppState, newValue?: string | undefined): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    const minimumOvertimeQuestionCount: number | undefined = getNumberOrUndefined(newValue);
+    if (minimumOvertimeQuestionCount != undefined) {
+        customizeGameFormatState.updateGameFormat({ minimumOvertimeQuestionCount });
+    }
+}
+
+export function changeBounceback(appState: AppState, checked?: boolean): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    if (checked == undefined) {
+        return;
+    }
+
+    customizeGameFormatState.updateGameFormat({ bonusesBounceBack: checked });
+}
+
+export function changeOvertimeBonuses(appState: AppState, checked?: boolean): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    if (checked == undefined) {
+        return;
+    }
+
+    customizeGameFormatState?.updateGameFormat({ overtimeIncludesBonuses: checked });
+}
+
+export function resetGameFormat(appState: AppState, gameFormat: IGameFormat): void {
+    appState.uiState.dialogState.customizeGameFormat?.updateGameFormat(gameFormat);
+}
+
+export function validatePowerSettings(appState: AppState): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+
+    customizeGameFormatState.clearPowerErrorMessages();
+    const powerValues: number[] = customizeGameFormatState.powerValues.split(",").map((value) => parseInt(value, 10));
+
+    if (customizeGameFormatState.powerMarkers.length < powerValues.length) {
+        customizeGameFormatState.setPowerMarkerErrorMessage(
+            "More power markers needed. The number of power markers and values must be the same."
+        );
+    } else if (powerValues.length < customizeGameFormatState.powerMarkers.length) {
+        customizeGameFormatState.setPowerValuesErrorMessage(
+            "More values needed. The number of power markers and values must be the same."
+        );
+    } else if (powerValues.some((value) => isNaN(value))) {
+        customizeGameFormatState.setPowerValuesErrorMessage("Power values must be integers.");
+    }
+}
+
+export function validatePronunicationGuideMarker(appState: AppState): void {
+    const customizeGameFormatState: CustomizeGameFormatDialogState = getState(appState);
+    const pronunciationGuideMarkers: string[] | undefined = customizeGameFormatState.pronunicationGuideMarkers;
+    if (pronunciationGuideMarkers == undefined) {
+        return;
+    }
+
+    if (pronunciationGuideMarkers.length !== 0 && pronunciationGuideMarkers.length !== 2) {
+        customizeGameFormatState.setPronunciationGuideMarkersErrorMessage(
+            "Either no pronunciation guide is used, or there only needs to be a start and end marker specifeid"
+        );
+    } else if (pronunciationGuideMarkers.some((value) => value.length === 0)) {
+        customizeGameFormatState.setPronunciationGuideMarkersErrorMessage(
+            "Pronunciation guide markers cannot be empty; put a character before or after the comma"
+        );
+    } else {
+        customizeGameFormatState.clearPronunciationGuideMarkersErrorMessage();
+    }
+}
+
+function getState(appState: AppState): CustomizeGameFormatDialogState {
+    const state: CustomizeGameFormatDialogState | undefined = appState.uiState.dialogState.customizeGameFormat;
+    if (state == undefined) {
+        throw new Error("Tried customizing a game format with no game format");
+    }
+
+    return state;
+}
+
+function getNumberOrUndefined(value: string | undefined): number | undefined {
+    if (value == undefined) {
+        return undefined;
+    }
+
+    const number = Number.parseInt(value, 10);
+    return isNaN(number) ? undefined : number;
+}
+
+function sortPowersDescending(left: IPowerMarker, right: IPowerMarker): number {
+    return right.points - left.points;
+}
+
+function isGameFormatValid(appState: AppState): boolean {
+    const state: CustomizeGameFormatDialogState | undefined = appState.uiState.dialogState.customizeGameFormat;
+    if (state == undefined) {
+        throw new Error("Tried changing a format with no modified format");
+    }
+
+    return (
+        state.powerMarkerErrorMessage == undefined &&
+        state.powerValuesErrorMessage == undefined &&
+        state.pronunciationGuideMarkersErrorMessage == undefined
+    );
+}
+
+function hideDialog(appState: AppState): void {
+    appState.uiState.dialogState.hideCustomizeGameFormatDialog();
+}

--- a/src/components/dialogs/ExportToJsonDialog.tsx
+++ b/src/components/dialogs/ExportToJsonDialog.tsx
@@ -40,6 +40,10 @@ const modalProps: IModalProps = {
     styles: {
         main: {
             top: "25vh",
+            // To have max width respected normally, we'd need to pass in an IDialogStyleProps, but it ridiculously
+            // requires you to pass in an entire theme to modify the max width. We could also use a modal, but that
+            // requires building much of what Dialogs offer easily (close buttons, footer for buttons)
+            minWidth: "30vw !important",
         },
     },
     topOffsetFixed: true,

--- a/src/components/dialogs/NewGameDialog.tsx
+++ b/src/components/dialogs/NewGameDialog.tsx
@@ -32,6 +32,7 @@ import { FromRostersTeamEntry } from "../FromRostersTeamEntry";
 import { SheetType } from "src/state/SheetState";
 import { GameFormatPicker } from "../GameFormatPicker";
 import { StateContext } from "src/contexts/StateContext";
+import { IGameFormat } from "src/state/IGameFormat";
 
 const playerListHeight = "20vh";
 
@@ -145,6 +146,15 @@ const NewGameDialogBody = observer(
             [uiState]
         );
 
+        const updateGameFormat = React.useCallback(
+            (gameFormat: IGameFormat) => appState.uiState.setPendingNewGameFormat(gameFormat),
+            [appState]
+        );
+
+        if (uiState.pendingNewGame == undefined) {
+            return <></>;
+        }
+
         // TODO: Have a selector for the format. Will need a way to specify a custom format
         return (
             <>
@@ -169,7 +179,14 @@ const NewGameDialogBody = observer(
                 <Separator />
                 <PacketLoader appState={appState} onLoad={packetLoadHandler} />
                 <Separator />
-                <GameFormatPicker />
+                <GameFormatPicker
+                    gameFormat={uiState.pendingNewGame.gameFormat}
+                    exportFormatSupportsBouncebacks={
+                        uiState.pendingNewGame.type !== PendingGameType.Lifsheets &&
+                        uiState.pendingNewGame.type !== PendingGameType.UCSDSheets
+                    }
+                    updateGameFormat={updateGameFormat}
+                />
             </>
         );
     }

--- a/src/qbj/QBJ.ts
+++ b/src/qbj/QBJ.ts
@@ -217,7 +217,7 @@ export function ToQBJ(game: GameState): string {
             const matchBuzz: IMatchQuestionBuzz | undefined = getBuzz(game, teams, buzz, isFirstBuzz);
             if (matchBuzz != undefined) {
                 matchQuestion.buzzes.push(matchBuzz);
-                updateAnswerCount(matchTeams, buzz);
+                updateAnswerCount(matchTeams, matchBuzz);
             }
 
             isFirstBuzz = false;
@@ -329,20 +329,22 @@ function getBuzz(
     );
 }
 
-function updateAnswerCount(matchTeams: Map<string, IMatchTeam>, buzz: ITossupAnswerEvent): void {
-    const matchTeam: IMatchTeam | undefined = matchTeams.get(buzz.marker.player.teamName);
+function updateAnswerCount(matchTeams: Map<string, IMatchTeam>, buzz: IMatchQuestionBuzz): void {
+    const matchTeam: IMatchTeam | undefined = matchTeams.get(buzz.team.name);
+
     if (matchTeam == undefined) {
         return;
     }
 
     const player: IMatchPlayer | undefined = matchTeam.match_players.find(
-        (matchPlayer) => matchPlayer.player.name === buzz.marker.player.name
+        (matchPlayer) => matchPlayer.player.name === buzz.player.name
     );
+
     if (player == undefined) {
         return;
     }
 
-    const points: number = buzz.marker.points;
+    const points: number = buzz.result.value;
     let answerCount: IPlayerAnswerCount | undefined = player.answer_counts.find(
         (answer) => answer.answer.value === points
     );

--- a/src/state/CustomizeGameFormatDialogState.ts
+++ b/src/state/CustomizeGameFormatDialogState.ts
@@ -8,7 +8,7 @@ export class CustomizeGameFormatDialogState {
     // (state shouldn't know about the view), which we should try to fix
     public powerMarkers: string[];
 
-    public powerValues: number[];
+    public powerValues: string;
 
     public pronunicationGuideMarkers: string[] | undefined;
 
@@ -25,7 +25,7 @@ export class CustomizeGameFormatDialogState {
         this.powerMarkers = this.gameFormat.powers.map((power) => power.marker);
         this.powerMarkerErrorMessage = undefined;
 
-        this.powerValues = this.gameFormat.powers.map((power) => power.points);
+        this.powerValues = this.gameFormat.powers.map((power) => power.points).join(",");
         this.powerValuesErrorMessage = undefined;
 
         this.pronunicationGuideMarkers = this.gameFormat.pronunciationGuideMarkers;
@@ -42,15 +42,19 @@ export class CustomizeGameFormatDialogState {
     }
 
     public setPowerMarkers(powerMarkers: string[]): void {
+        // Clear the error message if we have a new value
         this.powerMarkers = powerMarkers;
+        this.powerMarkerErrorMessage = undefined;
     }
 
     public setPowerMarkerErrorMessage(message: string): void {
         this.powerMarkerErrorMessage = message;
     }
 
-    public setPowerValues(powerValues: number[]): void {
+    public setPowerValues(powerValues: string): void {
+        // Clear the error message if we have a new value
         this.powerValues = powerValues;
+        this.powerValuesErrorMessage = undefined;
     }
 
     public setPowerValuesErrorMessage(message: string): void {
@@ -59,6 +63,7 @@ export class CustomizeGameFormatDialogState {
 
     public setPronunciationGuideMarkers(pronunciationGuideMarkers: string[]): void {
         this.pronunicationGuideMarkers = pronunciationGuideMarkers;
+        this.clearPronunciationGuideMarkersErrorMessage();
     }
 
     public setPronunciationGuideMarkersErrorMessage(message: string): void {
@@ -67,5 +72,15 @@ export class CustomizeGameFormatDialogState {
 
     public updateGameFormat(gameFormatUpdate: Partial<IGameFormat>): void {
         this.gameFormat = { ...this.gameFormat, ...gameFormatUpdate };
+
+        if (gameFormatUpdate.powers != undefined) {
+            this.setPowerValues(this.gameFormat.powers.map((power) => power.points).join(","));
+            this.setPowerMarkers(this.gameFormat.powers.map((power) => power.marker));
+        }
+
+        if (gameFormatUpdate.pronunciationGuideMarkers != undefined) {
+            this.pronunciationGuideMarkersErrorMessage = undefined;
+            this.pronunicationGuideMarkers = this.gameFormat.pronunciationGuideMarkers;
+        }
     }
 }

--- a/tests/AddPlayerDialogControllerTests.ts
+++ b/tests/AddPlayerDialogControllerTests.ts
@@ -1,0 +1,154 @@
+import { assert, expect } from "chai";
+
+import * as AddPlayerDialogController from "src/components/dialogs/AddPlayerDialogController";
+import { AppState } from "src/state/AppState";
+import { IPlayerJoinsEvent } from "src/state/Events";
+import { GameState } from "src/state/GameState";
+import { PacketState, Tossup } from "src/state/PacketState";
+import { Player } from "src/state/TeamState";
+
+const defaultPacket: PacketState = new PacketState();
+defaultPacket.setTossups([new Tossup("first q", "first a"), new Tossup("second q", "second a")]);
+
+const defaultTeamNames: string[] = ["First Team", "Team2"];
+
+function createApp(): AppState {
+    const gameState: GameState = new GameState();
+    gameState.loadPacket(defaultPacket);
+
+    const defaultExistingPlayers: Player[] = [
+        new Player("Frank", defaultTeamNames[0], true),
+        new Player("Faye", defaultTeamNames[0], true),
+        new Player("Saul", defaultTeamNames[1], true),
+    ];
+    gameState.addPlayers(defaultExistingPlayers);
+
+    const appState: AppState = new AppState();
+    appState.game = gameState;
+    appState.uiState.createPendingNewPlayer(defaultTeamNames[0]);
+    return appState;
+}
+
+function getPendingNewPlayer(appState: AppState): Player {
+    if (appState.uiState.pendingNewPlayer == undefined) {
+        assert.fail("PendingNewPlayer should not be undefined");
+    }
+
+    return appState.uiState.pendingNewPlayer;
+}
+
+describe("AddPlayerDialogControllerTests", () => {
+    it("changePlayerName", () => {
+        const name = "New player name";
+        const appState: AppState = createApp();
+        AddPlayerDialogController.changePlayerName(appState, name);
+        const player: Player = getPendingNewPlayer(appState);
+
+        expect(player.name).to.equal(name);
+        expect(player.teamName).to.equal(defaultTeamNames[0]);
+        expect(player.isStarter).to.be.false;
+    });
+    it("changeTeamName", () => {
+        const name = defaultTeamNames[1];
+        const appState: AppState = createApp();
+        AddPlayerDialogController.changePlayerName(appState, "Player");
+        AddPlayerDialogController.changeTeamName(appState, name);
+        const player: Player = getPendingNewPlayer(appState);
+
+        expect(player.name).to.equal("Player");
+        expect(player.teamName).to.equal(name);
+        expect(player.isStarter).to.be.false;
+    });
+    it("hideDialog", () => {
+        const appState: AppState = createApp();
+        AddPlayerDialogController.hideDialog(appState);
+
+        expect(appState.uiState.pendingNewPlayer).to.be.undefined;
+    });
+    describe("validatePlayer", () => {
+        it("validatePlayer - non-empty name", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changePlayerName(appState, " ");
+            const errorMessage: string | undefined = AddPlayerDialogController.validatePlayer(appState);
+            expect(errorMessage).to.not.be.undefined;
+        });
+        it("validatePlayer - non-existent team", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changeTeamName(appState, defaultTeamNames[0] + defaultTeamNames[1]);
+            const errorMessage: string | undefined = AddPlayerDialogController.validatePlayer(appState);
+            expect(errorMessage).to.not.be.undefined;
+        });
+        it("validatePlayer - valid player (no team change)", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changePlayerName(appState, "Newbie");
+            const errorMessage: string | undefined = AddPlayerDialogController.validatePlayer(appState);
+            expect(errorMessage).to.be.undefined;
+        });
+        it("validatePlayer - valid player (with team change)", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changeTeamName(appState, defaultTeamNames[1]);
+            AddPlayerDialogController.changePlayerName(appState, "Newbie");
+            const errorMessage: string | undefined = AddPlayerDialogController.validatePlayer(appState);
+            expect(errorMessage).to.be.undefined;
+        });
+    });
+    describe("addPlayer", () => {
+        it("addPlayer succeeds", () => {
+            const appState: AppState = createApp();
+            appState.uiState.setCycleIndex(1);
+            AddPlayerDialogController.changeTeamName(appState, defaultTeamNames[1]);
+            AddPlayerDialogController.changePlayerName(appState, "Newbie");
+            AddPlayerDialogController.addPlayer(appState);
+
+            // Verify - dialog hidden, player is in game, add player event in cycle
+            expect(appState.uiState.pendingNewPlayer).to.be.undefined;
+
+            const newPlayer: Player | undefined = appState.game.players.find(
+                (player) => player.name === "Newbie" && player.teamName === defaultTeamNames[1]
+            );
+            if (newPlayer == undefined) {
+                assert.fail(`Couldn't find new player in players: ${JSON.stringify(appState.game.players)}`);
+            }
+
+            expect(appState.game.cycles[0].playerJoins).to.be.undefined;
+
+            const playerJoins: IPlayerJoinsEvent[] | undefined = appState.game.cycles[1].playerJoins;
+            if (playerJoins === undefined) {
+                assert.fail("Expected joinPlayer event in the first cycle");
+            }
+
+            expect(playerJoins.length).to.equal(1);
+            expect(playerJoins[0].inPlayer).to.equal(newPlayer);
+        });
+        it("addPlayer fails (empty name)", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changeTeamName(appState, defaultTeamNames[1]);
+            AddPlayerDialogController.changePlayerName(appState, " ");
+            AddPlayerDialogController.addPlayer(appState);
+
+            // Verify - dialog hidden, player is in game, add player event in cycle
+            expect(appState.uiState.pendingNewPlayer).to.not.be.undefined;
+
+            const newPlayer: Player | undefined = appState.game.players.find(
+                (player) => player.name === " " && player.teamName === defaultTeamNames[1]
+            );
+            expect(newPlayer).to.be.undefined;
+
+            expect(appState.game.cycles[0].playerJoins).to.be.undefined;
+        });
+        it("addPlayer fails (non-existent team)", () => {
+            const appState: AppState = createApp();
+            AddPlayerDialogController.changeTeamName(appState, defaultTeamNames[0] + defaultTeamNames[1]);
+            AddPlayerDialogController.changePlayerName(appState, "Newbie");
+            AddPlayerDialogController.addPlayer(appState);
+
+            // Verify - dialog hidden, player is in game, add player event in cycle
+            expect(appState.uiState.pendingNewPlayer).to.not.be.undefined;
+
+            const newPlayer: Player | undefined = appState.game.players.find((player) => player.name === "Newbie");
+            expect(newPlayer).to.be.undefined;
+
+            expect(appState.game.cycles[0].playerJoins).to.be.undefined;
+        });
+    });
+});

--- a/tests/CustomizeGameFormatControllerTests.ts
+++ b/tests/CustomizeGameFormatControllerTests.ts
@@ -1,0 +1,228 @@
+import { expect } from "chai";
+
+import * as CustomizeGameFormatController from "src/components/dialogs/CustomGameFormatDialogController";
+import * as GameFormats from "src/state/GameFormats";
+import { AppState } from "src/state/AppState";
+import { GameState } from "src/state/GameState";
+import { PacketState, Tossup, Bonus } from "src/state/PacketState";
+import { IGameFormat } from "src/state/IGameFormat";
+
+const defaultPacket: PacketState = new PacketState();
+defaultPacket.setTossups([new Tossup("first q", "first a"), new Tossup("second q", "second a")]);
+defaultPacket.setBonuses([
+    new Bonus("first leadin", [
+        { question: "first q", answer: "first a", value: 10 },
+        { question: "first q 2", answer: "first a 2", value: 10 },
+        { question: "first q 3", answer: "first a 3", value: 10 },
+    ]),
+    new Bonus("second leadin", [
+        { question: "second q", answer: "second a", value: 10 },
+        { question: "second q 2", answer: "second a 2", value: 10 },
+        { question: "second q 3", answer: "second a 3", value: 10 },
+    ]),
+]);
+
+function createApp(): AppState {
+    const gameState: GameState = new GameState();
+    gameState.loadPacket(defaultPacket);
+
+    const appState: AppState = new AppState();
+    appState.game = gameState;
+    appState.uiState.dialogState.showCustomizeGameFormatDialog(gameState.gameFormat);
+
+    return appState;
+}
+
+function verifyNoPowerSettingsErrors(appState: AppState): void {
+    CustomizeGameFormatController.validatePowerSettings(appState);
+    expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkerErrorMessage).to.be.undefined;
+    expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.be.undefined;
+}
+
+describe("CustomizeGameFormatControllerTests", () => {
+    it("reset format", () => {
+        const appState: AppState = createApp();
+        appState.game.setGameFormat(GameFormats.PACEGameFormat);
+        appState.uiState.dialogState.showCustomizeGameFormatDialog(appState.game.gameFormat);
+        expect(appState.uiState.dialogState.customizeGameFormat?.gameFormat).to.deep.equal(GameFormats.PACEGameFormat);
+
+        CustomizeGameFormatController.resetGameFormat(appState, GameFormats.StandardPowersMACFGameFormat);
+        expect(appState.uiState.dialogState.customizeGameFormat?.gameFormat).to.deep.equal(
+            GameFormats.StandardPowersMACFGameFormat
+        );
+    });
+
+    it("changePowerMarkers", () => {
+        const appState: AppState = createApp();
+        CustomizeGameFormatController.changePowerMarkers(appState, "[+],(*)");
+        expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkers).to.deep.equal(["[+]", "(*)"]);
+    });
+
+    describe("pronounciationGuideValidation", () => {
+        it("No pronunciation guide is valid", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePronunciationGuideMarkers(appState, "");
+            CustomizeGameFormatController.validatePronunicationGuideMarker(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.pronunciationGuideMarkersErrorMessage).to.be
+                .undefined;
+        });
+        it("Valid pronunciation guide", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePronunciationGuideMarkers(appState, "<,>");
+            CustomizeGameFormatController.validatePronunicationGuideMarker(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.pronunciationGuideMarkersErrorMessage).to.be
+                .undefined;
+        });
+        it("Invalid pronunciation guide (only one side given)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePronunciationGuideMarkers(appState, "<");
+            CustomizeGameFormatController.validatePronunicationGuideMarker(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.pronunciationGuideMarkersErrorMessage).to.not.be
+                .undefined;
+        });
+        it("Invalid pronunciation guide (one side blank)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePronunciationGuideMarkers(appState, ",>");
+            CustomizeGameFormatController.validatePronunicationGuideMarker(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.pronunciationGuideMarkersErrorMessage).to.not.be
+                .undefined;
+        });
+    });
+
+    describe("validatePowerSettings", () => {
+        it("Default power settings are valid", () => {
+            const appState: AppState = createApp();
+            verifyNoPowerSettingsErrors(appState);
+        });
+        it("Single power setting is valid", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "15");
+            verifyNoPowerSettingsErrors(appState);
+        });
+        it("Multiple power settings are valid", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "[+],(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "20, 15");
+            verifyNoPowerSettingsErrors(appState);
+        });
+        it("Invalid power settings (markers but no values)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "[+],(*)");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.not.be.undefined;
+        });
+        it("Invalid power settings (more markers than values)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "[+],(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "15");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.not.be.undefined;
+
+            // Making the setting valid should clear the error
+            CustomizeGameFormatController.changePowerValues(appState, "20,15");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.be.undefined;
+        });
+        it("Invalid power settings (values but no markers)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerValues(appState, "20, 15");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkerErrorMessage).to.not.be.undefined;
+
+            // Making the setting valid should clear the error
+            CustomizeGameFormatController.changePowerMarkers(appState, "*,+");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkerErrorMessage).to.be.undefined;
+        });
+        it("Invalid power settings (more markers than values)", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "20, 15");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkerErrorMessage).to.not.be.undefined;
+        });
+        it("Invalid power settings (non-numeric power value))", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "a26z");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.not.be.undefined;
+        });
+    });
+
+    describe("submit", () => {
+        it("submit default form works", () => {
+            const appState: AppState = createApp();
+            const oldGameFormat: IGameFormat = appState.game.gameFormat;
+            CustomizeGameFormatController.submit(appState);
+
+            expect(appState.uiState.dialogState.customizeGameFormat).to.be.undefined;
+            expect(appState.game.gameFormat).to.deep.equal(oldGameFormat);
+        });
+        it("submit updates game format", () => {
+            const appState: AppState = createApp();
+            const oldGameFormat: IGameFormat = appState.game.gameFormat;
+            CustomizeGameFormatController.changeBounceback(appState, true);
+            CustomizeGameFormatController.changeMinimumQuestionsInOvertime(appState, "10");
+            CustomizeGameFormatController.changeNegValue(appState, "-10");
+            CustomizeGameFormatController.changeOvertimeBonuses(appState, true);
+            CustomizeGameFormatController.changePowerMarkers(appState, "<*>");
+            CustomizeGameFormatController.changePowerValues(appState, "25");
+            CustomizeGameFormatController.changePronunciationGuideMarkers(appState, "[,]");
+            CustomizeGameFormatController.changeRegulationTossupCount(appState, "15");
+            CustomizeGameFormatController.submit(appState);
+
+            expect(appState.uiState.dialogState.customizeGameFormat).to.be.undefined;
+
+            const expectedGameFormat: IGameFormat = {
+                ...oldGameFormat,
+                bonusesBounceBack: true,
+                displayName: "Custom",
+                minimumOvertimeQuestionCount: 10,
+                negValue: -10,
+                overtimeIncludesBonuses: true,
+                powers: [{ marker: "<*>", points: 25 }],
+                regulationTossupCount: 15,
+                pronunciationGuideMarkers: ["[", "]"],
+            };
+            expect(appState.game.gameFormat).to.deep.equal(expectedGameFormat);
+        });
+        it("submit has powers sorted", () => {
+            const appState: AppState = createApp();
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*),[+]");
+            CustomizeGameFormatController.changePowerValues(appState, "15,20");
+            CustomizeGameFormatController.submit(appState);
+
+            expect(appState.uiState.dialogState.customizeGameFormat).to.be.undefined;
+            expect(appState.game.gameFormat.powers).to.deep.equal([
+                { marker: "[+]", points: 20 },
+                { marker: "(*)", points: 15 },
+            ]);
+        });
+        it("submit does nothing with invalid power value settings", () => {
+            const appState: AppState = createApp();
+            const oldGameFormat: IGameFormat = appState.game.gameFormat;
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "a26z");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            CustomizeGameFormatController.submit(appState);
+
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerValuesErrorMessage).to.not.be.undefined;
+            expect(appState.uiState.dialogState.customizeGameFormat).to.not.be.undefined;
+            expect(appState.game.gameFormat).to.equal(oldGameFormat);
+        });
+        it("submit does nothing with invalid power marker settings", () => {
+            const appState: AppState = createApp();
+            const oldGameFormat: IGameFormat = appState.game.gameFormat;
+            CustomizeGameFormatController.changePowerMarkers(appState, "(*)");
+            CustomizeGameFormatController.changePowerValues(appState, "25,20");
+            CustomizeGameFormatController.validatePowerSettings(appState);
+            CustomizeGameFormatController.submit(appState);
+
+            expect(appState.uiState.dialogState.customizeGameFormat?.powerMarkerErrorMessage).to.not.be.undefined;
+            expect(appState.uiState.dialogState.customizeGameFormat).to.not.be.undefined;
+            expect(appState.game.gameFormat).to.equal(oldGameFormat);
+        });
+    });
+});


### PR DESCRIPTION
- Fix Add/Remove player regression (#112)
- Fix bug where buzzes were scored with their original GameFormat in QBJ exports instead of the latest GameFormat (#111)
- Redesign the Customize Format dialog (#101)
  - Sections split into tabs
  - Users can choose which pre-existing format to use
- Make export dialog wider in smaller screen resolutions
- Add tooltips explaining shortcuts for the Previous and Next buttons
- Bump version to 1.0.0