### PR TITLE
Merged PR 215: 1.2.2 - Fix ExportType, fix dev dependency security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -28,10 +28,10 @@ export class AppState {
         const customExport: ICustomExport = this.uiState.customExport;
         let exportPromise: Promise<IStatus> | undefined;
         switch (customExport.type) {
-            case ExportType.Raw:
+            case "Raw":
                 exportPromise = customExport.onExport(CustomExport.convertGameToExportFields(this.game));
                 break;
-            case ExportType.QBJ:
+            case "QBJ":
                 exportPromise = customExport.onExport(QBJ.toQBJ(this.game));
                 break;
             default:

--- a/src/state/CustomExport.ts
+++ b/src/state/CustomExport.ts
@@ -45,19 +45,16 @@ export interface IExportFields {
 
 interface ICustomRawExport extends IBaseCustomExport {
     onExport: (fields: IExportFields) => Promise<IStatus>;
-    type: ExportType.Raw;
+    type: "Raw";
 }
 
 interface ICustomQBJExport extends IBaseCustomExport {
     onExport: (qbj: IMatch) => Promise<IStatus>;
-    type: ExportType.QBJ;
+    type: "QBJ";
 }
 
 interface IBaseCustomExport {
     label: string;
 }
 
-export const enum ExportType {
-    Raw = "Raw",
-    QBJ = "QBJ",
-}
+export type ExportType = "Raw" | "QBJ";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,14 +2104,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
   integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
-  dependencies:
-    is-glob "^4.0.1"
-
-glob-parent@~5.1.2:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
- Fix ExportType to be a string, so it can be used by external components using ModaqControl
- Bump the version of glob-parent
- Bump version to 1.2.2