### PR TITLE
Merged PR 237: Bump version to 1.5.1 to deal with broken package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Bump version to 1.5.1 to deal with broken package (#140). This happened because of a bad `npm publish` command.