### PR TITLE
v1.8.0 - Substitution warnings, clearer Export button,…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/CycleChooser.tsx
+++ b/src/components/CycleChooser.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { DefaultButton, IButtonStyles } from "@fluentui/react/lib/Button";
+import { DefaultButton, IButtonStyles, PrimaryButton } from "@fluentui/react/lib/Button";
 import { TextField, ITextFieldStyles } from "@fluentui/react/lib/TextField";
 import { useId } from "@fluentui/react-hooks";
 
@@ -69,20 +69,39 @@ export const CycleChooser = observer(function CycleChooser() {
         </TooltipHost>
     );
 
+    let nextButton: JSX.Element;
+    let nextButtonTooltip;
     const doesNextButtonExport: boolean = shouldNextButtonExport(appState);
-    const nextButtonText: string = doesNextButtonExport ? "Export..." : "Next →";
-    const nextButtonTooltip: string = doesNextButtonExport ? "Export" : "Next (Shift+N)";
-    const nextButtonTooltipId: string = useId();
-    const nextButton: JSX.Element = (
-        <TooltipHost content={nextButtonTooltip} id={nextButtonTooltipId}>
-            <DefaultButton
-                aria-describedby={nextButtonTooltipId}
+    if (doesNextButtonExport) {
+        nextButtonTooltip = "Export";
+        nextButton = (
+            <PrimaryButton
+                aria-describedby={nextButtonTooltip}
                 key="nextButton"
                 onClick={onNextClickHandler}
                 styles={nextButtonStyle}
             >
-                {nextButtonText}
+                Export...
+            </PrimaryButton>
+        );
+    } else {
+        nextButtonTooltip = "Next (Shift+N)";
+        nextButton = (
+            <DefaultButton
+                aria-describedby={nextButtonTooltip}
+                key="nextButton"
+                onClick={onNextClickHandler}
+                styles={nextButtonStyle}
+            >
+                Next →
             </DefaultButton>
+        );
+    }
+
+    const nextButtonTooltipId: string = useId();
+    const nextButtonWrapper: JSX.Element = (
+        <TooltipHost content={nextButtonTooltip} id={nextButtonTooltipId}>
+            {nextButton}
         </TooltipHost>
     );
 
@@ -112,7 +131,7 @@ export const CycleChooser = observer(function CycleChooser() {
         <div>
             {previousButton}
             {questionNumberViewer}
-            {nextButton}
+            {nextButtonWrapper}
         </div>
     );
 });

--- a/src/components/ManualTeamEntry.tsx
+++ b/src/components/ManualTeamEntry.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { IIconProps, Label, List, mergeStyleSets } from "@fluentui/react";
+import { FocusZone, FocusZoneDirection, IIconProps, Label, List, mergeStyleSets } from "@fluentui/react";
 import { TextField, ITextFieldStyles } from "@fluentui/react/lib/TextField";
 import { IconButton, IButtonStyles } from "@fluentui/react/lib/Button";
 
 import * as NewGameValidator from "../state/NewGameValidator";
 import { Player } from "../state/TeamState";
 import { PlayerEntry } from "./PlayerEntry";
+
+const teamEntryClassName = "team-name-entry";
+const listCellClassName = "ms-List-cell";
 
 const addButtonProps: IIconProps = {
     iconName: "Add",
@@ -62,10 +65,11 @@ export const ManualTeamEntry = observer(function ManualTeamEntry(props: IManualT
 
     const addButtonDisabled: boolean = props.players.findIndex((player) => player.name === "") >= 0;
 
-    // TODO: Down key on the last player entry should trigger the addPlayerHandler
+    // Use a focus zone so that we only tab to a team entry instead of everything tabbable within the team entry
     return (
-        <div className={classes.teamEntry}>
+        <FocusZone direction={FocusZoneDirection.vertical} className={classes.teamEntry} onKeyDown={focusZoneKeyDown}>
             <TextField
+                className={teamEntryClassName}
                 label={props.teamLabel}
                 defaultValue={props.defaultTeamName}
                 errorMessage={props.teamNameErrorMessage}
@@ -88,8 +92,128 @@ export const ManualTeamEntry = observer(function ManualTeamEntry(props: IManualT
                     disabled={addButtonDisabled}
                 />
             </div>
-        </div>
+        </FocusZone>
     );
+
+    function focusZoneKeyDown(ev?: React.KeyboardEvent<HTMLElement>): void {
+        if (ev == undefined) {
+            return;
+        }
+
+        let change = 0;
+        switch (ev.key) {
+            case "ArrowDown":
+                // Go down a class if possible
+                change = 1;
+                break;
+            case "ArrowUp":
+                // Go up a class if possible
+                change = -1;
+                break;
+            default:
+                return;
+        }
+
+        // We doing focus handling manually here because Fabric UI isn't liking the nested FocusZones
+        const target: HTMLElement = ev.target as HTMLElement;
+
+        // Find the manual team entry container class, so we can look for other elements under it
+        let cellContainer = null;
+        let rootContainer = target;
+        while (rootContainer.parentElement != undefined && rootContainer.className.indexOf(classes.teamEntry) === -1) {
+            if (rootContainer.className.indexOf(listCellClassName) !== -1) {
+                cellContainer = rootContainer;
+            }
+
+            rootContainer = rootContainer.parentElement;
+        }
+
+        const cells = rootContainer.querySelectorAll("." + listCellClassName);
+
+        ev.stopPropagation();
+        ev.preventDefault();
+
+        // The class name isn't on the element that is focused, but on a child of it
+        if (
+            target.id != undefined &&
+            target.id.length > 0 &&
+            rootContainer.querySelector(`.${teamEntryClassName} #${target.id}`) != undefined
+        ) {
+            // Only go to the first cell if we pressed down
+            if (ev.key === "ArrowDown") {
+                // Focus on the first input of the first cell
+                focusOnFirstInputInPlayerEntry(cells[0] as HTMLElement);
+            }
+
+            return;
+        } else if (
+            target.tagName === "BUTTON" &&
+            rootContainer.querySelector("." + classes.addButtonContainer + " button") === target
+        ) {
+            if (ev.key === "ArrowUp") {
+                // Focus on the first input of the last cell
+                focusOnFirstInputInPlayerEntry(cells[cells.length - 1] as HTMLElement);
+            }
+
+            return;
+        }
+
+        if (cellContainer == undefined) {
+            // We're not in a cell, something weird has happened
+            return;
+        }
+
+        const rawListIndex: string | null = cellContainer.getAttribute("data-list-index");
+        if (rawListIndex == undefined) {
+            return;
+        }
+
+        let listIndex = Number.parseInt(rawListIndex);
+        listIndex += change;
+
+        if (listIndex >= cells.length) {
+            // Focus on the add player button if possible
+            const addButtonContainer: HTMLElement | null = rootContainer.getElementsByClassName(
+                classes.addButtonContainer
+            )[0] as HTMLElement;
+            if (addButtonContainer == undefined) {
+                return;
+            }
+
+            const addButton: HTMLElement | null = addButtonContainer.getElementsByTagName("button")[0] as HTMLElement;
+            if (addButton == undefined) {
+                return;
+            }
+
+            if (addButton.getAttribute("is-disabled") == null) {
+                addButton.focus();
+            }
+
+            return;
+        } else if (listIndex < 0) {
+            // Focus on the team name entry
+            const element: HTMLElement | null = rootContainer.querySelector(
+                `.${teamEntryClassName} input`
+            ) as HTMLElement;
+            element?.focus();
+        }
+
+        // Find the cell we need to go to, then focus on the same control if possible
+        const focusedCell: HTMLElement | null = cells[listIndex].firstChild as HTMLElement;
+        if (focusedCell == null) {
+            return;
+        }
+
+        // If we can get the control, go to it. Right now only the player name text box isn't selectable, but that's
+        // also the first element
+        const targetInNewCell: HTMLCollectionOf<Element> = focusedCell.getElementsByClassName(target.className);
+        if (targetInNewCell.length === 0) {
+            // Focus on the first input
+            focusOnFirstInputInPlayerEntry(focusedCell);
+        } else {
+            (targetInNewCell[0] as HTMLElement).focus();
+        }
+    }
 });
 
 function onRenderPlayerEntry(
@@ -112,6 +236,11 @@ function onRenderPlayerEntry(
             onRemovePlayerClick={onRemovePlayerHandler}
         />
     );
+}
+
+function focusOnFirstInputInPlayerEntry(playerEntryElement: HTMLElement): void {
+    // Focus on the first input in the player entry
+    playerEntryElement.getElementsByTagName("input")[0].focus();
 }
 
 const getClassNames = (playerListHeight: number | string): ITeamEntryClassNames =>

--- a/src/components/PlayerEntry.tsx
+++ b/src/components/PlayerEntry.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { Checkbox, ICheckboxStyles } from "@fluentui/react/lib/Checkbox";
 import { TextField, ITextFieldStyles } from "@fluentui/react/lib/TextField";
-import { ILabelStyles, Label, mergeStyleSets } from "@fluentui/react";
+import { FocusZone, FocusZoneDirection, ILabelStyles, Label, mergeStyleSets } from "@fluentui/react";
 
 import { Player } from "../state/TeamState";
 import { CancelButton } from "./CancelButton";
@@ -70,7 +70,7 @@ export const PlayerEntry = observer(function PlayerEntry(props: IPlayerEntryProp
     }
 
     return (
-        <div className={classes.playerEntryContainer}>
+        <FocusZone as="div" direction={FocusZoneDirection.horizontal} className={classes.playerEntryContainer}>
             {playerName}
             <Checkbox
                 label="Starter"
@@ -79,7 +79,7 @@ export const PlayerEntry = observer(function PlayerEntry(props: IPlayerEntryProp
                 checked={props.player.isStarter}
             />
             {cancelButtonOrSpacer}
-        </div>
+        </FocusZone>
     );
 });
 


### PR DESCRIPTION
… easier manual new game entry

- Prompt the user if they try making a substitution outside of beginning/halftime/end-of-game (#158)
- Change the background color of the next question button when it changes to Export to make it clearer to readers that they should export at the end of the game (#159)
- Add keyboarding to the team entry in the manual new game dialog to make it easier to add players (#157)
    - Up+down keys will move between the team name, different players, and the add player button
    - Left+right keys will move between the player name, is starter checkbox, and delete button
- Bump version to 1.8.0