### PR TITLE
v1.15.0 - custom export improvements, removed buzz points menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/CycleChooser.tsx
+++ b/src/components/CycleChooser.tsx
@@ -156,7 +156,7 @@ function onNextClick(appState: AppState): void {
     if (shouldNextButtonExport(appState)) {
         // If they use Sheets, show the Export Sheets dialog. Otherwise, show the Export JSON dialog
         if (appState.uiState.customExportOptions != undefined) {
-            appState.handleCustomExport(StatusDisplayType.MessageDialog);
+            appState.handleCustomExport(StatusDisplayType.MessageDialog, "NextButton");
         } else if (appState.uiState.sheetsState.sheetId != undefined) {
             appState.uiState.createPendingSheet();
         } else {

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -36,7 +36,7 @@ export const GameBar = observer(function GameBar(): JSX.Element {
                     // Open the export dialog, depending on if they have sheets. We should ideally abstract this logic
                     // to another method
                     if (appState.uiState.customExportOptions != undefined) {
-                        appState.handleCustomExport(StatusDisplayType.MessageDialog);
+                        appState.handleCustomExport(StatusDisplayType.MessageDialog, "NewGame");
                     } else if (appState.uiState.sheetsState.sheetId != undefined) {
                         exportToSheets(appState);
                     } else {
@@ -161,11 +161,34 @@ export const GameBar = observer(function GameBar(): JSX.Element {
             },
         });
     } else {
+        // This should be a split button, with custom as the default item
+        const handleCustomExport: () => void = () => {
+            appState.handleCustomExport(StatusDisplayType.MessageDialog, "Menu");
+        };
+
         items.push({
             key: "export",
             text: appState.uiState.customExportOptions.label,
-            onClick: () => {
-                appState.handleCustomExport(StatusDisplayType.MessageDialog);
+            disabled: appState.game.cycles.length === 0,
+            split: true,
+            onClick: handleCustomExport,
+            subMenuProps: {
+                items: [
+                    {
+                        key: "exportSubMenuItem",
+                        text: appState.uiState.customExportOptions.label,
+                        disabled: appState.game.cycles.length === 0,
+                        onClick: handleCustomExport,
+                    },
+                    {
+                        key: "downloadJson",
+                        text: "Backup to JSON...",
+                        disabled: appState.game.cycles.length === 0,
+                        onClick: () => {
+                            appState.uiState.dialogState.showExportToJsonDialog();
+                        },
+                    },
+                ],
             },
         });
     }
@@ -249,16 +272,6 @@ function getExportSubMenuItems(appState: AppState): ICommandBarItemProps[] {
         }
 
         return result.join("\t");
-    });
-    items.push({
-        key: "copyBuzzPoints",
-        text: "Copy buzz points",
-        disabled,
-        onClick: () => {
-            // Translate this to lines of tab delimited strings
-            const buzzPointsText: string = buzzPoints.join("\n");
-            copyText(buzzPointsText);
-        },
     });
 
     items.push({
@@ -661,31 +674,6 @@ function isSubMenuItemData(data: ISubMenuItemData | undefined): data is ISubMenu
 
 function isTossupProtestMenuItemData(data: ITossupProtestMenuItemData | undefined): data is ITossupProtestMenuItemData {
     return data?.appState !== undefined && data.buzz !== undefined;
-}
-
-// Adapted from this gist: https://gist.github.com/lgarron/d1dee380f4ed9d825ca7
-function copyText(text: string) {
-    return new Promise<void>(function (resolve, reject) {
-        let success = false;
-        function listener(e: ClipboardEvent) {
-            if (e == undefined || e.clipboardData == undefined) {
-                return;
-            }
-
-            e.clipboardData.setData("text/plain", text);
-            e.preventDefault();
-            success = true;
-        }
-
-        document.addEventListener("copy", listener);
-        document.execCommand("copy");
-        document.removeEventListener("copy", listener);
-        if (success) {
-            resolve();
-        } else {
-            reject();
-        }
-    });
 }
 
 interface ISubMenuItemData {

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -263,17 +263,6 @@ function getExportSubMenuItems(appState: AppState): ICommandBarItemProps[] {
         disabled: disabled || appState.uiState.sheetsState.clientId == undefined,
     });
 
-    // We have to compute this outside of onClick because MobX will complain about reading orderedBuzzes outside of a
-    // reaction otherwise
-    const buzzPoints: string[] = game.playableCycles.map((cycle) => {
-        const result: string[] = [];
-        for (const buzz of cycle.orderedBuzzes) {
-            result.push(buzz.marker.position.toString(10));
-        }
-
-        return result.join("\t");
-    });
-
     items.push({
         key: "downloadJson",
         text: "Export to JSON...",

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -32,8 +32,13 @@ export class AppState {
 
     // Could do a version with callbacks. There are 4 places this gets called from, and 3 use the same callback
     // Could also just do a bool, and pass in a different value (e.g. enum) if we want more flexibility in the future
-    public handleCustomExport(displayType: StatusDisplayType): Promise<void> {
-        if (this.uiState == undefined || this.uiState.customExportOptions == undefined) {
+    public handleCustomExport(displayType: StatusDisplayType, source: CustomExport.ExportSource): Promise<void> {
+        // Custom export must be defined and we must have an existing game
+        if (
+            this.uiState == undefined ||
+            this.uiState.customExportOptions == undefined ||
+            this.game.cycles.length === 0
+        ) {
             return Promise.resolve();
         }
 
@@ -41,10 +46,10 @@ export class AppState {
         let exportPromise: Promise<IStatus> | undefined;
         switch (customExport.type) {
             case "Raw":
-                exportPromise = customExport.onExport(CustomExport.convertGameToExportFields(this.game));
+                exportPromise = customExport.onExport(CustomExport.convertGameToExportFields(this.game), { source });
                 break;
             case "QBJ":
-                exportPromise = customExport.onExport(QBJ.toQBJ(this.game, this.uiState.packetFilename));
+                exportPromise = customExport.onExport(QBJ.toQBJ(this.game, this.uiState.packetFilename), { source });
                 break;
             default:
                 assertNever(customExport);
@@ -112,7 +117,7 @@ export class AppState {
             interval = minimumIntervalInMs;
         }
 
-        const newIntervalId = setInterval(() => this.handleCustomExport(StatusDisplayType.Label), interval);
+        const newIntervalId = setInterval(() => this.handleCustomExport(StatusDisplayType.Label, "Timer"), interval);
         this.uiState.setCustomExportIntervalId(newIntervalId);
     }
 }

--- a/src/state/CustomExport.ts
+++ b/src/state/CustomExport.ts
@@ -43,13 +43,17 @@ export interface IExportFields {
     packet: IPacket;
 }
 
+export interface IExportContext {
+    source: ExportSource;
+}
+
 interface ICustomRawExport extends IBaseCustomExport {
-    onExport: (fields: IExportFields) => Promise<IStatus>;
+    onExport: (fields: IExportFields, context?: IExportContext) => Promise<IStatus>;
     type: "Raw";
 }
 
 interface ICustomQBJExport extends IBaseCustomExport {
-    onExport: (qbj: IMatch) => Promise<IStatus>;
+    onExport: (qbj: IMatch, context?: IExportContext) => Promise<IStatus>;
     type: "QBJ";
 }
 
@@ -65,3 +69,5 @@ interface IBaseCustomExport {
 }
 
 export type ExportType = "Raw" | "QBJ";
+
+export type ExportSource = "Menu" | "NewGame" | "NextButton" | "Timer";


### PR DESCRIPTION
- Fix issue where `onExport` was called when a game wasn't ready (#198)
- `onExport` now takes in a second optional parameter that gives some context about the export. For now it only says what the source of the export was (e.g. next button, timer). This can be used to figure out when the export for the end of the game is. (#199)
- Add an option to back up the game as a JSON of the game state or a QBJ file when the host uses a custom export (#196)
- Remove the "Copy Buzz points" menu item since it's unnecessary (export to Lifsheets works)
- Bump version to 1.15.0