### PR TITLE
v1.22.0 - Pronunciation guide colors, tossup/bonus numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -16,7 +16,7 @@ export const Answer = observer(function Answer(props: IAnswerProps): JSX.Element
 
     return (
         <div>
-            <span className={props.className}>ANSWER:&nbsp;</span>
+            <span className={props.className}>ANSWER: </span>
             <FormattedText segments={formattedText} className={props.className} />
         </div>
     );

--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -17,7 +17,7 @@ export const Answer = observer(function Answer(props: IAnswerProps): JSX.Element
     return (
         <div>
             <span className={props.className}>ANSWER: </span>
-            <FormattedText segments={formattedText} className={props.className} />
+            <FormattedText segments={formattedText} className={props.className} disabled={props.disabled} />
         </div>
     );
 });
@@ -25,4 +25,5 @@ export const Answer = observer(function Answer(props: IAnswerProps): JSX.Element
 export interface IAnswerProps {
     text: string;
     className?: string;
+    disabled?: boolean;
 }

--- a/src/components/BonusQuestion.tsx
+++ b/src/components/BonusQuestion.tsx
@@ -30,8 +30,9 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
         BonusQuestionController.throwOutBonus(props.cycle, props.bonusIndex);
     }, [props]);
     const formattedLeadin: IFormattedText[] = React.useMemo(
-        () => PacketState.getBonusWords(props.bonus.leadin, props.appState.game.gameFormat),
-        [props.bonus.leadin, props.appState.game.gameFormat]
+        () =>
+            PacketState.getBonusWords(`${props.bonusIndex + 1}. ${props.bonus.leadin}`, props.appState.game.gameFormat),
+        [props.bonusIndex, props.bonus.leadin, props.appState.game.gameFormat]
     );
     const [lastBonus, setLastBonus] = React.useState(props.bonus);
 
@@ -65,6 +66,7 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
         }
     }
 
+    const disabled = !props.inPlay;
     const parts: JSX.Element[] = props.bonus.parts.map((bonusPartProps, index) => {
         return (
             <BonusQuestionPart
@@ -74,7 +76,7 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
                 gameFormat={props.appState.game.gameFormat}
                 partNumber={index + 1}
                 teamNames={props.appState.game.teamNames}
-                disabled={!props.inPlay}
+                disabled={disabled}
             />
         );
     });
@@ -97,7 +99,11 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
                         <Stack horizontal={true}>
                             <StackItem id={bonusQuestionTextId} styles={stackItemStyles}>
                                 <FocusZone as="div" shouldRaiseClicks={true} direction={FocusZoneDirection.vertical}>
-                                    <FormattedText className={classes.bonusLeadin} segments={formattedLeadin} />
+                                    <FormattedText
+                                        className={classes.bonusLeadin}
+                                        segments={formattedLeadin}
+                                        disabled={disabled}
+                                    />
                                     {parts}
                                     {metadata}
                                 </FocusZone>
@@ -107,7 +113,7 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
                             </StackItem>
                             <StackItem>
                                 <CancelButton
-                                    disabled={!props.inPlay}
+                                    disabled={disabled}
                                     tooltip="Throw out bonus"
                                     onClick={throwOutClickHandler}
                                 />
@@ -149,7 +155,6 @@ const getClassNames = (theme: ITheme | undefined, fontSize: number, disabled: bo
         bonusMetadata: [
             {
                 paddingLeft: 24,
-                marginTop: "-1em",
             },
             disabled && {
                 color: theme ? theme.palette.neutralSecondaryAlt : "#888888",

--- a/src/components/FormattedText.tsx
+++ b/src/components/FormattedText.tsx
@@ -3,9 +3,12 @@ import { observer } from "mobx-react-lite";
 import { mergeStyleSets, memoizeFunction } from "@fluentui/react";
 
 import { IFormattedText } from "../parser/IFormattedText";
+import { StateContext } from "../contexts/StateContext";
+import { AppState } from "../state/AppState";
 
 export const FormattedText = observer(function FormattedText(props: IFormattedTextProps): JSX.Element {
-    const classes: IFormattedTextClassNames = useStyles();
+    const appState: AppState = React.useContext(StateContext);
+    const classes: IFormattedTextClassNames = useStyles(appState.uiState.pronunciationGuideColor);
 
     const elements: JSX.Element[] = [];
     for (let i = 0; i < props.segments.length; i++) {
@@ -64,7 +67,7 @@ interface IFormattedTextClassNames {
 }
 
 const useStyles = memoizeFunction(
-    (): IFormattedTextClassNames =>
+    (pronunciationGuideColor: string | undefined): IFormattedTextClassNames =>
         mergeStyleSets({
             text: {
                 display: "inline",
@@ -72,7 +75,7 @@ const useStyles = memoizeFunction(
             pronunciationGuide: {
                 // TODO: This is the one place theming doesn't work well; all of the netural colors have poor contrast
                 // or don't stick out enough from regular text.
-                color: "#777777",
+                color: pronunciationGuideColor ?? "#777777",
             },
         })
 );

--- a/src/components/FormattedText.tsx
+++ b/src/components/FormattedText.tsx
@@ -8,7 +8,7 @@ import { AppState } from "../state/AppState";
 
 export const FormattedText = observer(function FormattedText(props: IFormattedTextProps): JSX.Element {
     const appState: AppState = React.useContext(StateContext);
-    const classes: IFormattedTextClassNames = useStyles(appState.uiState.pronunciationGuideColor);
+    const classes: IFormattedTextClassNames = useStyles(appState.uiState.pronunciationGuideColor, props.disabled);
 
     const elements: JSX.Element[] = [];
     for (let i = 0; i < props.segments.length; i++) {
@@ -54,6 +54,7 @@ const FormattedSegment = observer(function FormattedSegment(props: IFormattedSeg
 export interface IFormattedTextProps {
     segments: IFormattedText[];
     className?: string;
+    disabled?: boolean;
 }
 
 interface IFormattedSegmentProps {
@@ -67,15 +68,14 @@ interface IFormattedTextClassNames {
 }
 
 const useStyles = memoizeFunction(
-    (pronunciationGuideColor: string | undefined): IFormattedTextClassNames =>
+    (pronunciationGuideColor: string | undefined, disabled: boolean | undefined): IFormattedTextClassNames =>
         mergeStyleSets({
             text: {
                 display: "inline",
             },
             pronunciationGuide: {
-                // TODO: This is the one place theming doesn't work well; all of the netural colors have poor contrast
-                // or don't stick out enough from regular text.
-                color: pronunciationGuideColor ?? "#777777",
+                // Don't override the color if it's disabled; the container has that responsibility
+                color: disabled ? undefined : pronunciationGuideColor ?? "#777777",
             },
         })
 );

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -330,7 +330,7 @@ function getOptionsSubMenuItems(appState: AppState): ICommandBarItemProps[] {
             key: "font",
             text: "Font...",
             onClick: () => {
-                appState.uiState.setPendingFontSize(appState.uiState.questionFontSize);
+                appState.uiState.showFontDialog();
             },
         }
     );

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -387,6 +387,14 @@ function getViewSubMenuItems(appState: AppState): ICommandBarItemProps[] {
             checked: appState.uiState.isScoreVertical,
             onClick: () => appState.uiState.toggleScoreVerticality(),
         },
+        {
+            key: "highlightBonus",
+            text: "Highlight Bonus",
+            title: "Highlight the background of answered bonuses",
+            canCheck: true,
+            checked: !appState.uiState.noBonusHighlight,
+            onClick: () => appState.uiState.toggleBonusHighlight(),
+        },
     ]);
 
     items = items.concat([

--- a/src/components/QuestionViewer.tsx
+++ b/src/components/QuestionViewer.tsx
@@ -6,7 +6,15 @@ import { GameState } from "../state/GameState";
 import { TossupQuestion } from "./TossupQuestion";
 import { BonusQuestion } from "./BonusQuestion";
 import { Cycle } from "../state/Cycle";
-import { ISeparatorStyles, IStackStyles, mergeStyleSets, Separator, Stack, StackItem } from "@fluentui/react";
+import {
+    ISeparatorStyles,
+    IStackStyles,
+    memoizeFunction,
+    mergeStyleSets,
+    Separator,
+    Stack,
+    StackItem,
+} from "@fluentui/react";
 import { AppState } from "../state/AppState";
 import { StateContext } from "../contexts/StateContext";
 
@@ -20,7 +28,7 @@ export const QuestionViewer = observer(function QuestionViewer() {
     const appState: AppState = React.useContext(StateContext);
     const fontSize: number = appState.uiState.questionFontSize;
     const fontFamily: string = appState.uiState.fontFamily;
-    const classes: IQuestionViewerClassNames = getClassNames(fontSize);
+    const classes: IQuestionViewerClassNames = getClassNames(appState.uiState.questionFontColor, fontSize);
     const game: GameState = appState.game;
     const uiState: UIState = appState.uiState;
 
@@ -105,15 +113,18 @@ interface IQuestionViewerClassNames {
     separator: string;
 }
 
-const getClassNames = (fontSize: number): IQuestionViewerClassNames =>
-    mergeStyleSets({
-        questionViewer: {
-            border: "1px solid darkgray",
-            padding: "5px 10px",
-            fontSize,
-        },
-        separator: {
-            borderTop: "1px dotted black",
-            margin: "10px 0",
-        },
-    });
+const getClassNames = memoizeFunction(
+    (fontColor: string | undefined, fontSize: number): IQuestionViewerClassNames =>
+        mergeStyleSets({
+            questionViewer: {
+                border: "1px solid darkgray",
+                padding: "5px 10px",
+                fontSize,
+                color: fontColor,
+            },
+            separator: {
+                borderTop: "1px dotted black",
+                margin: "10px 0",
+            },
+        })
+);

--- a/src/components/TossupQuestion.tsx
+++ b/src/components/TossupQuestion.tsx
@@ -37,18 +37,22 @@ export const TossupQuestion = observer(function TossupQuestion(props: IQuestionP
 
     const words: ITossupWord[] = props.tossup.getWords(props.appState.game.gameFormat);
 
-    const questionWords: JSX.Element[] = words.map((word) => (
-        <QuestionWordWrapper
-            key={word.canBuzzOn ? `qw_${word.wordIndex}` : `nqw_${word.nonWordIndex}`}
-            correctBuzzIndex={correctBuzzIndex}
-            index={word.canBuzzOn ? word.wordIndex : undefined}
-            isLastWord={word.canBuzzOn && word.isLastWord}
-            selectedWordRef={selectedWordRef}
-            word={word.word}
-            wrongBuzzIndexes={wrongBuzzIndexes}
-            {...props}
-        />
-    ));
+    let questionWords: JSX.Element[] = [<span key="tuNumber">{props.tossupNumber}. </span>];
+
+    questionWords = questionWords.concat(
+        words.map((word) => (
+            <QuestionWordWrapper
+                key={word.canBuzzOn ? `qw_${word.wordIndex}` : `nqw_${word.nonWordIndex}`}
+                correctBuzzIndex={correctBuzzIndex}
+                index={word.canBuzzOn ? word.wordIndex : undefined}
+                isLastWord={word.canBuzzOn && word.isLastWord}
+                selectedWordRef={selectedWordRef}
+                word={word.word}
+                wrongBuzzIndexes={wrongBuzzIndexes}
+                {...props}
+            />
+        ))
+    );
 
     const throwOutClickHandler: () => void = React.useCallback(() => {
         TossupQuestionController.throwOutTossup(props.cycle, props.tossupNumber);
@@ -150,6 +154,6 @@ const getClassNames = (): ITossupQuestionClassNames =>
         },
         tossupQuestionText: {
             display: "inline-block",
-            marginBottom: "0.25em",
+            marginBottom: "0.5em",
         },
     });

--- a/src/components/dialogs/FontDialogController.ts
+++ b/src/components/dialogs/FontDialogController.ts
@@ -1,3 +1,4 @@
+import { FontDialogState } from "../../state/FontDialogState";
 import { AppState } from "../../state/AppState";
 
 export const defaultFont = "Segoe UI";
@@ -13,27 +14,52 @@ export function changePendingSize(newValue: string): void {
 
     const size = Number.parseInt(newValue, 10);
     if (!isNaN(size)) {
-        appState.uiState.setPendingFontSize(size);
+        appState.uiState.dialogState.fontDialog?.setFontSize(size);
     }
 }
 
 export function changeFontFamily(newValue: string | undefined): void {
-    AppState.instance.uiState.setPendingFontFamily(newValue ?? defaultFont);
+    AppState.instance.uiState.dialogState.fontDialog?.setFontFamily(newValue ?? defaultFont);
+}
+
+export function changePronunciationGuideColor(color: string | undefined): void {
+    if (color == undefined) {
+        AppState.instance.uiState.dialogState.fontDialog?.resetPronunciationGuideColor();
+    } else {
+        AppState.instance.uiState.dialogState.fontDialog?.setPronunciationGuideColor(color);
+    }
+}
+
+export function changeTextColor(color: string | undefined): void {
+    if (color == undefined) {
+        AppState.instance.uiState.dialogState.fontDialog?.resetTextColor();
+    } else {
+        AppState.instance.uiState.dialogState.fontDialog?.setTextColor(color);
+    }
 }
 
 export function update(): void {
     const appState: AppState = AppState.instance;
-    if (appState.uiState.pendingFontFamily != undefined) {
-        appState.uiState.setFontFamily(appState.uiState.pendingFontFamily ?? defaultFont);
+    const dialogState: FontDialogState | undefined = appState.uiState.dialogState.fontDialog;
+    if (dialogState == undefined) {
+        return;
     }
 
-    if (appState.uiState.pendingFontSize != undefined) {
-        appState.uiState.setQuestionFontSize(appState.uiState.pendingFontSize ?? minimumFontSize);
+    if (dialogState.fontFamily != undefined) {
+        appState.uiState.setFontFamily(appState.uiState.dialogState.fontDialog?.fontFamily ?? defaultFont);
     }
+
+    if (dialogState.fontSize != undefined) {
+        appState.uiState.setQuestionFontSize(appState.uiState.dialogState.fontDialog?.fontSize ?? minimumFontSize);
+    }
+
+    // undefined is the default color for text/pronunciation guide color, so always set it to what the dialog had
+    appState.uiState.setPronunciationGuideColor(dialogState.pronunciationGuideColor);
+    appState.uiState.setQuestionFontColor(dialogState.textColor);
 
     hideDialog();
 }
 
 function hideDialog(): void {
-    AppState.instance.uiState.resetPendingFonts();
+    AppState.instance.uiState.dialogState.hideFontDialog();
 }

--- a/src/components/dialogs/ScoresheetDialog.tsx
+++ b/src/components/dialogs/ScoresheetDialog.tsx
@@ -222,7 +222,7 @@ function renderBonusCell(
             bonusTotal += part.points;
         }
 
-        lines.push(<span key={`Bonus_${cycleIndex}_${teamName}_Total`}>&nbsp;{bonusTotal}</span>);
+        lines.push(<span key={`Bonus_${cycleIndex}_${teamName}_Total`}> {bonusTotal}</span>);
 
         return (
             <td className={`${classNames.bonusCell} ${classNames.tableCell}`} key={`Bonus_${cycleIndex}_${teamName}`}>

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -7,6 +7,7 @@ import { IMessageDialogState, MessageDialogType } from "./IMessageDialogState";
 import { RenamePlayerDialogState } from "./RenamePlayerDialogState";
 import { Player } from "./TeamState";
 import { ReorderPlayersDialogState } from "./ReorderPlayersDialogState";
+import { FontDialogState } from "./FontDialogState";
 
 export class DialogState {
     @ignore
@@ -17,6 +18,9 @@ export class DialogState {
 
     @ignore
     public exportToJsonDialogVisible: boolean;
+
+    @ignore
+    public fontDialog: FontDialogState | undefined;
 
     @ignore
     public helpDialogVisible: boolean;
@@ -47,6 +51,7 @@ export class DialogState {
         this.exportToJsonDialogVisible = false;
         this.helpDialogVisible = false;
         this.importGameDialogVisible = false;
+        this.fontDialog = undefined;
         this.messageDialog = undefined;
         this.newGameDialogVisible = false;
         this.renamePlayerDialog = undefined;
@@ -72,6 +77,10 @@ export class DialogState {
 
     public hideImportGameDialog(): void {
         this.importGameDialogVisible = false;
+    }
+
+    public hideFontDialog(): void {
+        this.fontDialog = undefined;
     }
 
     public hideMessageDialog(): void {
@@ -104,6 +113,20 @@ export class DialogState {
 
     public showExportToJsonDialog(): void {
         this.exportToJsonDialogVisible = true;
+    }
+
+    public showFontDialog(
+        existingFontFamily: string,
+        existingFontSize: number,
+        existingTextColor: string | undefined,
+        existingPronunciationGuideColor: string | undefined
+    ): void {
+        this.fontDialog = new FontDialogState(
+            existingFontFamily,
+            existingFontSize,
+            existingTextColor,
+            existingPronunciationGuideColor
+        );
     }
 
     public showHelpDialog(): void {

--- a/src/state/FontDialogState.ts
+++ b/src/state/FontDialogState.ts
@@ -1,0 +1,57 @@
+import { makeAutoObservable } from "mobx";
+import { ignore } from "mobx-sync";
+
+export const DefaultFontFamily =
+    "Segoe UI, Times New Roman, -apple-system, BlinkMacSystemFont, Roboto, Helvetica Neue, serif";
+
+export class FontDialogState {
+    @ignore
+    public fontFamily: string | undefined;
+
+    @ignore
+    public fontSize: number | undefined;
+
+    @ignore
+    public pronunciationGuideColor: string | undefined;
+
+    @ignore
+    public textColor: string | undefined;
+
+    constructor(
+        fontFamily: string | undefined,
+        fontSize: number | undefined,
+        textColor: string | undefined,
+        pronunciationGuideColor: string | undefined
+    ) {
+        makeAutoObservable(this);
+
+        this.fontFamily = fontFamily;
+        this.fontSize = fontSize;
+        this.pronunciationGuideColor = pronunciationGuideColor;
+        this.textColor = textColor;
+    }
+
+    public resetPronunciationGuideColor(): void {
+        this.pronunciationGuideColor = undefined;
+    }
+
+    public resetTextColor(): void {
+        this.textColor = undefined;
+    }
+
+    public setFontFamily(listedFont: string): void {
+        this.fontFamily = listedFont + ", " + DefaultFontFamily;
+    }
+
+    public setFontSize(fontSize: number): void {
+        this.fontSize = fontSize;
+    }
+
+    public setPronunciationGuideColor(color: string): void {
+        this.pronunciationGuideColor = color;
+    }
+
+    public setTextColor(color: string): void {
+        this.textColor = color;
+    }
+}

--- a/src/state/GameFormats.ts
+++ b/src/state/GameFormats.ts
@@ -18,8 +18,8 @@ export const ACFGameFormat: IGameFormat = {
 };
 
 export const PACEGameFormat: IGameFormat = {
-    bonusesBounceBack: true,
-    displayName: "PACE (pre-2022)",
+    bonusesBounceBack: false,
+    displayName: "PACE",
     minimumOvertimeQuestionCount: 1,
     overtimeIncludesBonuses: false,
     negValue: 0,

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -94,6 +94,9 @@ export class UIState {
     // Default should be to have it horizontal.
     public isScoreVertical: boolean;
 
+    // Default should be to highlight answered bonuses
+    public noBonusHighlight: boolean;
+
     public pronunciationGuideColor: string | undefined;
 
     public questionFontColor: string | undefined;
@@ -132,6 +135,7 @@ export class UIState {
         this.isCustomExportStatusHidden = false;
         this.isScoreVertical = false;
         this.importGameStatus = undefined;
+        this.noBonusHighlight = false;
         this.packetFilename = undefined;
         this.packetParseStatus = undefined;
         this.pendingBonusProtestEvent = undefined;
@@ -465,6 +469,10 @@ export class UIState {
 
     public setYappServiceUrl(url: string | undefined): void {
         this.yappServiceUrl = url;
+    }
+
+    public toggleBonusHighlight(): void {
+        this.noBonusHighlight = !this.noBonusHighlight;
     }
 
     public toggleClockVisibility(): void {

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -77,12 +77,6 @@ export class UIState {
     public pendingNewPlayer?: Player;
 
     @ignore
-    public pendingFontFamily?: string;
-
-    @ignore
-    public pendingFontSize?: number;
-
-    @ignore
     public pendingSheet?: IPendingSheet;
 
     @ignore
@@ -99,6 +93,10 @@ export class UIState {
 
     // Default should be to have it horizontal.
     public isScoreVertical: boolean;
+
+    public pronunciationGuideColor: string | undefined;
+
+    public questionFontColor: string | undefined;
 
     public questionFontSize: number;
 
@@ -139,13 +137,14 @@ export class UIState {
         this.pendingBonusProtestEvent = undefined;
         this.pendingNewGame = undefined;
         this.pendingNewPlayer = undefined;
-        this.pendingFontFamily = undefined;
-        this.pendingFontSize = undefined;
         this.pendingSheet = undefined;
         this.pendingTossupProtestEvent = undefined;
         this.useDarkMode = false;
         this.yappServiceUrl = undefined;
 
+        // These are defined by the theme if not set explicitly
+        this.pronunciationGuideColor = undefined;
+        this.questionFontColor = undefined;
         // The default font size is 16px
         this.questionFontSize = 16;
         this.sheetsState = new SheetState();
@@ -233,6 +232,13 @@ export class UIState {
     }
 
     public setFontFamily(listedFont: string): void {
+        // It's possible the listed font has default fonts listed too. Cut them out so that we don't keep compounding
+        // the default fonts on top.
+        const commaIndex: number = listedFont.indexOf(",");
+        if (commaIndex >= 0) {
+            listedFont = listedFont.substring(0, commaIndex);
+        }
+
         this.fontFamily = listedFont + ", " + DefaultFontFamily;
     }
 
@@ -417,14 +423,6 @@ export class UIState {
         this.packetFilename = name;
     }
 
-    public setPendingFontFamily(font: string): void {
-        this.pendingFontFamily = font;
-    }
-
-    public setPendingFontSize(size: number): void {
-        this.pendingFontSize = size;
-    }
-
     public setPacketStatus(packetStatus: IStatus): void {
         this.packetParseStatus = packetStatus;
     }
@@ -447,6 +445,14 @@ export class UIState {
             reason: "",
             teamName,
         };
+    }
+
+    public setPronunciationGuideColor(color: string | undefined): void {
+        this.pronunciationGuideColor = color;
+    }
+
+    public setQuestionFontColor(color: string | undefined): void {
+        this.questionFontColor = color;
     }
 
     public setQuestionFontSize(size: number): void {
@@ -535,11 +541,6 @@ export class UIState {
         this.pendingNewPlayer = undefined;
     }
 
-    public resetPendingFonts(): void {
-        this.pendingFontFamily = undefined;
-        this.pendingFontSize = undefined;
-    }
-
     public resetPendingSheet(): void {
         this.pendingSheet = undefined;
     }
@@ -556,6 +557,16 @@ export class UIState {
     public showBuzzMenu(clearSelectedWordOnClose: boolean): void {
         this.buzzMenuState.visible = true;
         this.buzzMenuState.clearSelectedWordOnClose = clearSelectedWordOnClose;
+    }
+
+    // We have to do this call here because this is where the information is available
+    public showFontDialog(): void {
+        this.dialogState.showFontDialog(
+            this.fontFamily,
+            this.questionFontSize,
+            this.questionFontColor,
+            this.pronunciationGuideColor
+        );
     }
 
     public updatePendingProtestGivenAnswer(givenAnswer: string): void {

--- a/tests/FontDialogControllerTests.ts
+++ b/tests/FontDialogControllerTests.ts
@@ -2,51 +2,84 @@ import { expect } from "chai";
 
 import * as FontDialogController from "src/components/dialogs/FontDialogController";
 import { AppState } from "src/state/AppState";
+import { DefaultFontFamily, FontDialogState } from "src/state/FontDialogState";
 
-function initializeApp(): AppState {
+function initializeApp(): { appState: AppState; dialogState: FontDialogState } {
     AppState.resetInstance();
     const appState: AppState = AppState.instance;
-    appState.uiState.setPendingFontSize(16);
-    return appState;
+    appState.uiState.setQuestionFontSize(16);
+    showFontDialog(appState);
+
+    const dialogState: FontDialogState | undefined = appState.uiState.dialogState.fontDialog;
+    if (dialogState == undefined) {
+        throw "Dialog state should be defined";
+    }
+
+    return { appState, dialogState };
 }
 
-// Need tests for FontDC
+function showFontDialog(appState: AppState): void {
+    appState.uiState.dialogState.showFontDialog(
+        appState.uiState.fontFamily,
+        appState.uiState.questionFontSize,
+        appState.uiState.questionFontColor,
+        appState.uiState.pronunciationGuideColor
+    );
+}
 
 describe("FontDialogControllerTests", () => {
     it("changeFontFamily specific font", () => {
-        const appState: AppState = initializeApp();
+        const { dialogState } = initializeApp();
 
         const newFontFamily = "Comic Sans MS";
         FontDialogController.changeFontFamily(newFontFamily);
 
-        expect(appState.uiState.pendingFontFamily).to.equal(newFontFamily);
+        expect(dialogState.fontFamily).to.equal(newFontFamily + ", " + DefaultFontFamily);
     });
 
     it("changeFontFamily default font", () => {
-        const appState: AppState = initializeApp();
+        const { dialogState } = initializeApp();
 
         FontDialogController.changeFontFamily(undefined);
 
-        expect(appState.uiState.pendingFontFamily).to.equal(FontDialogController.defaultFont);
+        expect(dialogState.fontFamily).to.equal(FontDialogController.defaultFont + ", " + DefaultFontFamily);
     });
 
-    it("changePendingSize", () => {
-        const appState: AppState = initializeApp();
+    it("changeFontSize", () => {
+        const { dialogState } = initializeApp();
 
-        const oldFontSize = appState.uiState.pendingFontSize;
+        const oldFontSize = dialogState.fontSize;
         const newFontSize = (oldFontSize ?? 16) + 8;
         FontDialogController.changePendingSize(newFontSize.toString());
 
-        expect(appState.uiState.pendingFontSize).to.equal(newFontSize);
+        expect(dialogState.fontSize).to.equal(newFontSize);
     });
 
-    it("changePendingSize for invalid value", () => {
-        const appState: AppState = initializeApp();
+    it("changeFontSize for invalid value", () => {
+        const { dialogState } = initializeApp();
 
-        const oldFontSize = appState.uiState.pendingFontSize;
+        const oldFontSize = dialogState.fontSize;
         FontDialogController.changePendingSize("xyz");
 
-        expect(appState.uiState.pendingFontSize).to.equal(oldFontSize);
+        expect(dialogState.fontSize).to.equal(oldFontSize);
+    });
+
+    it("changeTextColor", () => {
+        const { dialogState } = initializeApp();
+
+        const textColor = "black";
+        FontDialogController.changeTextColor(textColor);
+
+        expect(dialogState.textColor).to.equal(textColor);
+    });
+
+    it("changePronunciationGuideColor", () => {
+        const { dialogState } = initializeApp();
+
+        const pronunciationGuideColor = "purple";
+        FontDialogController.changePronunciationGuideColor(pronunciationGuideColor);
+
+        expect(dialogState.pronunciationGuideColor).to.equal(pronunciationGuideColor);
     });
 
     it("update only font size", () => {
@@ -54,14 +87,13 @@ describe("FontDialogControllerTests", () => {
         const appState: AppState = AppState.instance;
         appState.uiState.setFontFamily("Comic Sans MS");
         appState.uiState.setQuestionFontSize(16);
-
-        appState.uiState.setPendingFontSize(16);
+        showFontDialog(appState);
 
         FontDialogController.changePendingSize("40");
         FontDialogController.update();
 
-        expect(appState.uiState.pendingFontFamily).to.be.undefined;
-        expect(appState.uiState.pendingFontSize).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
         expect(appState.uiState.questionFontSize).to.equal(40);
         expect(appState.uiState.fontFamily.startsWith("Comic Sans MS")).to.be.true;
     });
@@ -71,36 +103,69 @@ describe("FontDialogControllerTests", () => {
         const appState: AppState = AppState.instance;
         appState.uiState.setFontFamily("Comic Sans MS");
         appState.uiState.setQuestionFontSize(40);
+        showFontDialog(appState);
 
-        appState.uiState.setPendingFontFamily("Arial");
+        FontDialogController.changeFontFamily("Arial");
         FontDialogController.update();
 
-        expect(appState.uiState.pendingFontFamily).to.be.undefined;
-        expect(appState.uiState.pendingFontSize).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
         expect(appState.uiState.questionFontSize).to.equal(40);
         expect(appState.uiState.fontFamily.startsWith("Arial")).to.be.true;
     });
 
-    it("update both", () => {
-        const appState: AppState = initializeApp();
+    it("update all", () => {
+        const { appState } = initializeApp();
 
         FontDialogController.changePendingSize("40");
         FontDialogController.changeFontFamily("Comic Sans MS");
+        FontDialogController.changeTextColor("black");
+        FontDialogController.changePronunciationGuideColor("blue");
         FontDialogController.update();
 
-        expect(appState.uiState.pendingFontFamily).to.be.undefined;
-        expect(appState.uiState.pendingFontSize).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontSize).to.be.undefined;
         expect(appState.uiState.questionFontSize).to.equal(40);
         expect(appState.uiState.fontFamily.startsWith("Comic Sans MS")).to.be.true;
+        expect(appState.uiState.questionFontColor).to.equal("black");
+        expect(appState.uiState.pronunciationGuideColor).to.equal("blue");
+    });
+
+    it("resest question text color", () => {
+        AppState.resetInstance();
+        const appState: AppState = AppState.instance;
+        appState.uiState.setQuestionFontColor("black");
+        showFontDialog(appState);
+
+        FontDialogController.changeTextColor(undefined);
+        FontDialogController.update();
+
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.questionFontColor).to.be.undefined;
+    });
+
+    it("resest pronunciation guide color", () => {
+        AppState.resetInstance();
+        const appState: AppState = AppState.instance;
+        appState.uiState.setPronunciationGuideColor("purple");
+        showFontDialog(appState);
+
+        FontDialogController.changePronunciationGuideColor(undefined);
+        FontDialogController.update();
+
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.pronunciationGuideColor).to.be.undefined;
     });
 
     it("hideDialog", () => {
-        const appState: AppState = initializeApp();
-        expect(appState.uiState.pendingFontSize).to.not.be.undefined;
+        const { appState, dialogState } = initializeApp();
+        expect(dialogState.fontSize).to.not.be.undefined;
 
         FontDialogController.cancel();
 
-        expect(appState.uiState.pendingFontFamily).to.be.undefined;
-        expect(appState.uiState.pendingFontSize).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontFamily).to.be.undefined;
+        expect(appState.uiState.dialogState.fontDialog?.fontSize).to.be.undefined;
     });
 });

--- a/tests/QBJTests.ts
+++ b/tests/QBJTests.ts
@@ -467,7 +467,6 @@ describe("QBJTests", () => {
 
                     packet.setTossups(tossups);
                     game.loadPacket(packet);
-                    console.log("Packet length: " + game.packet.tossups.length);
 
                     game.cycles[0].addWrongBuzz(
                         {


### PR DESCRIPTION
- Allow users to pick between a few different colors for the pronunciation guide font color (#210)
- Allow users to make the question text color black instead of a very dark gray
- Add tossup/bonus number for the question (#231)
- Add a correct/incorrect background highlight for bonus parts where we know their correctness (#209)
- When the cycle changes, scroll to it in the Event Viewer (#227)
- Fix bug where pronunciation guide color was applied even if the bonus was disabled
- Bump version to 1.22.0