### PR TITLE
v1.23.0 - New game improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -11,7 +11,7 @@ import * as React from "react";
 import { observer } from "mobx-react-lite";
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from "@fluentui/react/lib/ContextualMenu";
 
-import * as CompareUtils from "../state/CompareUtils";
+import * as PlayerUtils from "../state/PlayerUtils";
 import { Player } from "../state/TeamState";
 import { Cycle } from "../state/Cycle";
 import { Tossup } from "../state/PacketState";
@@ -69,13 +69,13 @@ function getPlayerMenuItems(props: IBuzzMenuProps, theme: Theme | undefined, tea
         const topLevelKey = `Team_${teamName}_Player_${index}`;
         const isCorrectChecked: boolean =
             props.cycle.correctBuzz != undefined &&
-            CompareUtils.playersEqual(props.cycle.correctBuzz.marker.player, player) &&
+            PlayerUtils.playersEqual(props.cycle.correctBuzz.marker.player, player) &&
             props.cycle.correctBuzz.marker.position === props.wordIndex;
         const isWrongChecked: boolean =
             props.cycle.wrongBuzzes != undefined &&
             props.cycle.wrongBuzzes.findIndex(
                 (buzz) =>
-                    CompareUtils.playersEqual(buzz.marker.player, player) && buzz.marker.position === props.wordIndex
+                    PlayerUtils.playersEqual(buzz.marker.player, player) && buzz.marker.position === props.wordIndex
             ) >= 0;
         const isProtestChecked: boolean =
             props.cycle.tossupProtests?.findIndex((protest) => protest.position === props.wordIndex) != undefined;

--- a/src/components/FromRostersTeamEntry.tsx
+++ b/src/components/FromRostersTeamEntry.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { Dropdown, IDropdownOption, List, mergeStyleSets } from "@fluentui/react";
+import { Dropdown, IDropdownOption, mergeStyleSets } from "@fluentui/react";
 
 import { Player } from "../state/TeamState";
-import { PlayerEntry } from "./PlayerEntry";
+import { PlayerRoster } from "./PlayerRoster";
 
 export const FromRostersTeamEntry = observer(function FromRostersTeamEntry(props: IFromRostersTeamEntryProps) {
     const classes: ITeamEntryClassNames = getClassNames(props.playerListHeight);
@@ -41,19 +41,17 @@ export const FromRostersTeamEntry = observer(function FromRostersTeamEntry(props
                 errorMessage={props.teamNameErrorMessage}
             />
             <div className={classes.playerListContainer} data-is-scrollable="true">
-                <List items={[...props.players]} onRenderCell={onRenderPlayerEntry} />
+                <PlayerRoster
+                    canSetStarter={true}
+                    players={props.players}
+                    onMovePlayerBackward={props.onMovePlayerBackward}
+                    onMovePlayerForward={props.onMovePlayerForward}
+                    onMovePlayerToIndex={props.onMovePlayerToIndex}
+                />
             </div>
         </div>
     );
 });
-
-function onRenderPlayerEntry(player: Player | undefined): JSX.Element {
-    if (player == undefined) {
-        return <></>;
-    }
-
-    return <PlayerEntry player={player} readonly={true} />;
-}
 
 // TODO: Unify with ManualTeamEntry
 const getClassNames = (playerListHeight: number | string): ITeamEntryClassNames =>
@@ -77,6 +75,9 @@ export interface IFromRostersTeamEntryProps {
     playerPool: Player[];
     teamLabel: string;
     teamNameErrorMessage?: string;
+    onMovePlayerBackward: (player: Player) => void;
+    onMovePlayerForward: (player: Player) => void;
+    onMovePlayerToIndex: (player: Player, index: number) => void;
     onTeamChange(newTeamName: string, players: Player[]): void;
 }
 

--- a/src/components/ManualTeamEntry.tsx
+++ b/src/components/ManualTeamEntry.tsx
@@ -228,13 +228,15 @@ function onRenderPlayerEntry(
 
     const required: boolean = index === 0;
     return (
-        <PlayerEntry
-            canRemove={index !== 0}
-            player={player}
-            required={required}
-            validateName={playerNameValidationHandler}
-            onRemovePlayerClick={onRemovePlayerHandler}
-        />
+        <FocusZone as="div" direction={FocusZoneDirection.horizontal}>
+            <PlayerEntry
+                canRemove={index !== 0}
+                player={player}
+                required={required}
+                validateName={playerNameValidationHandler}
+                onRemovePlayerClick={onRemovePlayerHandler}
+            />
+        </FocusZone>
     );
 }
 

--- a/src/components/PlayerEntry.tsx
+++ b/src/components/PlayerEntry.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import { Checkbox, ICheckboxStyles } from "@fluentui/react/lib/Checkbox";
 import { TextField, ITextFieldStyles } from "@fluentui/react/lib/TextField";
-import { FocusZone, FocusZoneDirection, ILabelStyles, Label, mergeStyleSets } from "@fluentui/react";
+import { ILabelStyles, Label, mergeStyleSets } from "@fluentui/react";
 
 import { Player } from "../state/TeamState";
 import { CancelButton } from "./CancelButton";
@@ -27,7 +27,7 @@ const starterCheckboxStyle: Partial<ICheckboxStyles> = {
     },
 };
 
-export const PlayerEntry = observer(function PlayerEntry(props: IPlayerEntryProps) {
+export const PlayerEntry = observer(function PlayerEntry(props: React.PropsWithChildren<IPlayerEntryProps>) {
     const classes: IPlayerEntryClassNames = getClassNames();
 
     const starterChangeHandler = React.useCallback(
@@ -69,17 +69,22 @@ export const PlayerEntry = observer(function PlayerEntry(props: IPlayerEntryProp
         playerName = <Label styles={playerNameLabelStyle}>{props.player.name}</Label>;
     }
 
+    const checkbox = props.canSetStarter !== false && (
+        <Checkbox
+            label="Starter"
+            onChange={starterChangeHandler}
+            styles={starterCheckboxStyle}
+            checked={props.player.isStarter}
+        />
+    );
+
     return (
-        <FocusZone as="div" direction={FocusZoneDirection.horizontal} className={classes.playerEntryContainer}>
+        <div className={classes.playerEntryContainer}>
             {playerName}
-            <Checkbox
-                label="Starter"
-                onChange={starterChangeHandler}
-                styles={starterCheckboxStyle}
-                checked={props.player.isStarter}
-            />
+            {checkbox}
             {cancelButtonOrSpacer}
-        </FocusZone>
+            {props.children}
+        </div>
     );
 });
 
@@ -97,10 +102,11 @@ interface IEditablePlayerEntryProps extends IBasePlayerEntryProps {
 }
 
 interface IReadonlyPlayerEntryProps extends IBasePlayerEntryProps {
-    readonly: true;
+    isNameReadonly: true;
 }
 
 interface IBasePlayerEntryProps {
+    canSetStarter?: boolean;
     player: Player;
 }
 

--- a/src/components/PlayerRoster.tsx
+++ b/src/components/PlayerRoster.tsx
@@ -1,0 +1,177 @@
+// List of players that can be re-organized through drag+drop
+import * as React from "react";
+import { observer } from "mobx-react-lite";
+import {
+    IStackTokens,
+    IColumn,
+    IIconProps,
+    IDragDropEvents,
+    IconButton,
+    Stack,
+    StackItem,
+    CheckboxVisibility,
+    DetailsList,
+    SelectionMode,
+    IStackStyles,
+} from "@fluentui/react";
+
+import { Player } from "../state/TeamState";
+import { PlayerEntry } from "./PlayerEntry";
+
+const buttonTokens: IStackTokens = { childrenGap: 10 };
+
+const playerEntryStyle: IStackStyles = {
+    root: {
+        flexGrow: 1,
+        paddingRight: 10,
+    },
+};
+
+const columns: IColumn[] = [
+    {
+        key: "name",
+        fieldName: "name",
+        name: "name",
+        minWidth: 30,
+    },
+];
+
+const downButtonProps: IIconProps = {
+    iconName: "ChevronDown",
+};
+
+const upButtonProps: IIconProps = {
+    iconName: "ChevronUp",
+};
+
+const rowStyle: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+};
+
+const moveDownClassName = "moveDownButton";
+const moveUpClassName = "moveUpButton";
+
+// Accessibility issue: can't tab/move to the checkbox; it's taken over by the buttons
+export const PlayerRoster = observer(function PlayerRoster(props: IPlayerRosterProps): JSX.Element {
+    const [draggedItem, setDraggedItem] = React.useState<Player | undefined>(undefined);
+    const [autoFocusIndex, setAutoFocusIndex] = React.useState<number | undefined>(undefined);
+    const [autoFocusIsUp, setAutoFocusIsUp] = React.useState<boolean>(false);
+    const [teamName, setTeamName] = React.useState<string | undefined>(undefined);
+
+    // Need to reset auto-focus if the team changes
+    React.useEffect(() => {
+        if (props.players.length > 0 && props.players[0].teamName !== teamName) {
+            setTeamName(props.players[0].teamName);
+            setAutoFocusIndex(undefined);
+        }
+    }, [props.players, setTeamName, setAutoFocusIndex, teamName]);
+
+    React.useEffect(() => {
+        // This makes sure that the focus stays on the button belonging to the player
+        if (autoFocusIndex != undefined) {
+            const className: string = autoFocusIsUp ? moveUpClassName : moveDownClassName;
+            const element = document.getElementsByClassName(className)[autoFocusIndex] as HTMLButtonElement;
+            if (element) {
+                element.focus();
+            }
+
+            setAutoFocusIndex(undefined);
+        }
+    }, [autoFocusIndex, autoFocusIsUp, props.players, setAutoFocusIndex]);
+
+    function renderPlayerRow(player: Player | undefined, index: number | undefined) {
+        if (player == undefined || index == undefined) {
+            return <></>;
+        }
+
+        return (
+            <div style={rowStyle}>
+                <StackItem styles={playerEntryStyle}>
+                    <PlayerEntry player={player} isNameReadonly={true} canSetStarter={props.canSetStarter}>
+                        <Stack horizontal={true} tokens={buttonTokens}>
+                            <StackItem>
+                                <IconButton
+                                    className={moveUpClassName}
+                                    iconProps={upButtonProps}
+                                    disabled={index === 0}
+                                    onClick={() => {
+                                        props.onMovePlayerForward(player);
+                                        if (index > 1) {
+                                            setAutoFocusIsUp(true);
+                                            setAutoFocusIndex(index - 1);
+                                        }
+                                    }}
+                                />
+                            </StackItem>
+                            <StackItem>
+                                <IconButton
+                                    className={moveDownClassName}
+                                    iconProps={downButtonProps}
+                                    disabled={index >= props.players.length - 1}
+                                    onClick={() => {
+                                        props.onMovePlayerBackward(player);
+                                        if (index < props.players.length - 1) {
+                                            setAutoFocusIsUp(false);
+                                            setAutoFocusIndex(index + 1);
+                                        }
+                                    }}
+                                />
+                            </StackItem>
+                        </Stack>
+                    </PlayerEntry>
+                </StackItem>
+            </div>
+        );
+    }
+
+    function insertBeforeItem(item: Player) {
+        if (draggedItem == undefined) {
+            return;
+        }
+
+        const locationIndex = props.players.indexOf(item);
+        const itemIndex = props.players.indexOf(draggedItem);
+        if (locationIndex !== itemIndex) {
+            props.onMovePlayerToIndex(draggedItem, locationIndex);
+        }
+    }
+
+    const dragDropEvents: IDragDropEvents = {
+        canDrag: () => true,
+        canDrop: () => true,
+        onDragStart: (item?: Player) => {
+            setDraggedItem(item);
+        },
+        onDragEnd: () => {
+            setDraggedItem(undefined);
+        },
+        onDrop: (item?: Player) => {
+            if (draggedItem && item) {
+                insertBeforeItem(item);
+                setDraggedItem(undefined);
+            }
+        },
+    };
+
+    return (
+        <DetailsList
+            checkboxVisibility={CheckboxVisibility.hidden}
+            columns={columns}
+            dragDropEvents={dragDropEvents}
+            isHeaderVisible={false}
+            items={props.players}
+            onRenderItemColumn={renderPlayerRow}
+            selectionMode={SelectionMode.single}
+        ></DetailsList>
+    );
+});
+
+export interface IPlayerRosterProps {
+    canSetStarter: boolean;
+    players: Player[];
+    onMovePlayerForward: (player: Player) => void;
+    onMovePlayerBackward: (player: Player) => void;
+    onMovePlayerToIndex: (player: Player, index: number) => void;
+}

--- a/src/components/dialogs/ImportGameDialog.tsx
+++ b/src/components/dialogs/ImportGameDialog.tsx
@@ -294,7 +294,7 @@ function onSubmit(appState: AppState): void {
     game.addPlayers(firstTeamPlayers.filter((player) => player.name !== ""));
     game.addPlayers(secondTeamPlayers.filter((player) => player.name !== ""));
     game.loadPacket(pendingNewGame.packet);
-    game.setCycles(pendingNewGame.cycles ?? []);
+    game.setCycles(pendingNewGame.manual.cycles ?? []);
 
     // If we've just started a new game, start at the beginning
     uiState.setCycleIndex(0);

--- a/src/components/dialogs/ReorderPlayerDialog.tsx
+++ b/src/components/dialogs/ReorderPlayerDialog.tsx
@@ -14,14 +14,7 @@ import {
     Stack,
     Label,
     StackItem,
-    IconButton,
-    IIconProps,
     IStackTokens,
-    DetailsList,
-    SelectionMode,
-    IColumn,
-    CheckboxVisibility,
-    IDragDropEvents,
 } from "@fluentui/react";
 
 import * as ReorderPlayersDialogController from "../../components/dialogs/ReorderPlayersDialogController";
@@ -29,6 +22,7 @@ import { Player } from "../../state/TeamState";
 import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { ReorderPlayersDialogState } from "../../state/ReorderPlayersDialogState";
+import { PlayerRoster } from "../PlayerRoster";
 
 const content: IDialogContentProps = {
     type: DialogType.normal,
@@ -58,35 +52,7 @@ const modalProps: IModalProps = {
     topOffsetFixed: true,
 };
 
-const buttonTokens: IStackTokens = { childrenGap: 10 };
-
 const dialogBodyTokens: IStackTokens = { childrenGap: 10 };
-
-const columns: IColumn[] = [
-    {
-        key: "name",
-        fieldName: "name",
-        name: "name",
-        minWidth: 30,
-    },
-];
-
-const downButtonProps: IIconProps = {
-    iconName: "ChevronDown",
-};
-
-const upButtonProps: IIconProps = {
-    iconName: "ChevronUp",
-};
-
-const rowStyle: React.CSSProperties = {
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
-};
-
-const moveDownClassName = "moveDownButton";
-const moveUpClassName = "moveUpButton";
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const ReorderPlayerDialog = observer(function ReorderPlayerDialog(): JSX.Element {
@@ -111,14 +77,9 @@ export const ReorderPlayerDialog = observer(function ReorderPlayerDialog(): JSX.
 const ReorderPlayerDialogBody = observer(function ReorderPlayerDialogBody(): JSX.Element {
     const appState: AppState = React.useContext(StateContext);
 
-    const [draggedItem, setDraggedItem] = React.useState<Player | undefined>(undefined);
-    const [autoFocusIndex, setAutoFocusIndex] = React.useState<number | undefined>(undefined);
-    const [autoFocusIsUp, setAutoFocusIsUp] = React.useState<boolean>(false);
-
     const teamChangeHandler = React.useCallback((ev: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
         if (option?.text != undefined) {
             ReorderPlayersDialogController.changeTeamName(option.text);
-            setAutoFocusIndex(undefined);
         }
     }, []);
 
@@ -126,17 +87,6 @@ const ReorderPlayerDialogBody = observer(function ReorderPlayerDialogBody(): JSX
         appState.uiState.dialogState.reorderPlayersDialog;
     if (reorderPlayersDialog === undefined) {
         return <></>;
-    }
-
-    // This makes sure that the focus stays on the button belonging to the player
-    if (autoFocusIndex != undefined) {
-        const className: string = autoFocusIsUp ? moveUpClassName : moveDownClassName;
-        const element = document.getElementsByClassName(className)[autoFocusIndex] as HTMLButtonElement;
-        if (element) {
-            element.focus();
-        }
-
-        setAutoFocusIndex(undefined);
     }
 
     const teamOptions: IDropdownOption[] = appState.game.teamNames.map((teamName, index) => {
@@ -148,79 +98,6 @@ const ReorderPlayerDialogBody = observer(function ReorderPlayerDialogBody(): JSX
     });
 
     const players: Player[] = reorderPlayersDialog.players.filter((p) => p.teamName === reorderPlayersDialog.teamName);
-
-    function renderPlayerRow(player: Player | undefined, index: number | undefined) {
-        if (player == undefined || index == undefined || reorderPlayersDialog == undefined) {
-            return <></>;
-        }
-
-        return (
-            <div style={rowStyle}>
-                <StackItem>
-                    <Label>{player.name}</Label>
-                </StackItem>
-                <Stack horizontal={true} tokens={buttonTokens}>
-                    <StackItem>
-                        <IconButton
-                            className={moveUpClassName}
-                            iconProps={upButtonProps}
-                            disabled={index === 0}
-                            onClick={() => {
-                                ReorderPlayersDialogController.moveForward(player);
-                                if (index > 1) {
-                                    setAutoFocusIsUp(true);
-                                    setAutoFocusIndex(index - 1);
-                                }
-                            }}
-                        />
-                    </StackItem>
-                    <StackItem>
-                        <IconButton
-                            className={moveDownClassName}
-                            iconProps={downButtonProps}
-                            disabled={index >= players.length - 1}
-                            onClick={() => {
-                                ReorderPlayersDialogController.moveBackward(player);
-                                if (index < players.length - 1) {
-                                    setAutoFocusIsUp(false);
-                                    setAutoFocusIndex(index + 1);
-                                }
-                            }}
-                        />
-                    </StackItem>
-                </Stack>
-            </div>
-        );
-    }
-
-    function insertBeforeItem(item: Player) {
-        if (draggedItem == undefined) {
-            return;
-        }
-
-        const locationIndex = players.indexOf(item);
-        const itemIndex = players.indexOf(draggedItem);
-        if (locationIndex !== itemIndex) {
-            ReorderPlayersDialogController.movePlayerToIndex(draggedItem, locationIndex);
-        }
-    }
-
-    const dragDropEvents: IDragDropEvents = {
-        canDrag: () => true,
-        canDrop: () => true,
-        onDragStart: (item?: Player) => {
-            setDraggedItem(item);
-        },
-        onDragEnd: () => {
-            setDraggedItem(undefined);
-        },
-        onDrop: (item?: Player) => {
-            if (draggedItem && item) {
-                insertBeforeItem(item);
-                setDraggedItem(undefined);
-            }
-        },
-    };
 
     return (
         <Stack tokens={dialogBodyTokens}>
@@ -234,15 +111,13 @@ const ReorderPlayerDialogBody = observer(function ReorderPlayerDialogBody(): JSX
                 <Dropdown label="Team" options={teamOptions} onChange={teamChangeHandler} />
             </StackItem>
             <StackItem>
-                <DetailsList
-                    checkboxVisibility={CheckboxVisibility.hidden}
-                    columns={columns}
-                    dragDropEvents={dragDropEvents}
-                    isHeaderVisible={false}
-                    items={players}
-                    onRenderItemColumn={renderPlayerRow}
-                    selectionMode={SelectionMode.single}
-                ></DetailsList>
+                <PlayerRoster
+                    canSetStarter={false}
+                    players={players}
+                    onMovePlayerBackward={ReorderPlayersDialogController.moveBackward}
+                    onMovePlayerForward={ReorderPlayersDialogController.moveForward}
+                    onMovePlayerToIndex={ReorderPlayersDialogController.movePlayerToIndex}
+                />
             </StackItem>
         </Stack>
     );

--- a/src/components/dialogs/ScoresheetDialog.tsx
+++ b/src/components/dialogs/ScoresheetDialog.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
 
-import * as CompareUtils from "../../state/CompareUtils";
 import * as FormattedTextParser from "../../parser/FormattedTextParser";
+import * as PlayerUtils from "../../state/PlayerUtils";
 import { Cycle } from "../../state/Cycle";
 import { AppState } from "../../state/AppState";
 import {
@@ -285,7 +285,7 @@ function renderPlayerCell(
 ): JSX.Element {
     // if this is too inefficient (because we check all players for the correct buzz), move to using a map. This means
     // we need existing cells that we can overwrite. From testing, this seems to be fine.
-    if (cycle.correctBuzz && CompareUtils.playersEqual(cycle.correctBuzz.marker.player, player)) {
+    if (cycle.correctBuzz && PlayerUtils.playersEqual(cycle.correctBuzz.marker.player, player)) {
         const correctPoints: number = cycle.correctBuzz.marker.points;
         const answer = getUnformattedAnswer(game, game.packet.tossups[cycle.correctBuzz.tossupIndex].answer);
 
@@ -306,7 +306,7 @@ function renderPlayerCell(
         );
     } else if (cycle.wrongBuzzes) {
         const wrongBuzz: ITossupAnswerEvent | undefined = cycle.wrongBuzzes.find((buzz) =>
-            CompareUtils.playersEqual(buzz.marker.player, player)
+            PlayerUtils.playersEqual(buzz.marker.player, player)
         );
         if (wrongBuzz) {
             const wrongPoints: number = wrongBuzz.marker.points;

--- a/src/state/CompareUtils.ts
+++ b/src/state/CompareUtils.ts
@@ -1,5 +1,0 @@
-import { IPlayer } from "./TeamState";
-
-export function playersEqual(player: IPlayer, other: IPlayer): boolean {
-    return player.name === other.name && player.teamName === other.teamName;
-}

--- a/src/state/Cycle.ts
+++ b/src/state/Cycle.ts
@@ -1,8 +1,8 @@
 import { observable, action, computed, makeObservable } from "mobx";
 import { format } from "mobx-sync";
 
-import * as CompareUtils from "./CompareUtils";
 import * as Events from "./Events";
+import * as PlayerUtils from "./PlayerUtils";
 import { IBuzzMarker } from "./IBuzzMarker";
 import { IGameFormat } from "./IGameFormat";
 import { IPlayer } from "./TeamState";
@@ -321,7 +321,7 @@ export class Cycle implements ICycle {
         // There's no need to keep them in both lists.
         if (this.playerJoins != undefined) {
             const joinEvent: Events.IPlayerJoinsEvent | undefined = this.playerJoins.find((event) =>
-                CompareUtils.playersEqual(event.inPlayer, outPlayer)
+                PlayerUtils.playersEqual(event.inPlayer, outPlayer)
             );
             if (joinEvent) {
                 this.playerJoins = this.playerJoins.filter((event) => event !== joinEvent);
@@ -590,7 +590,7 @@ export class Cycle implements ICycle {
         }
 
         const oldLength: number = this.wrongBuzzes.length;
-        this.wrongBuzzes = this.wrongBuzzes.filter((buzz) => !CompareUtils.playersEqual(buzz.marker.player, player));
+        this.wrongBuzzes = this.wrongBuzzes.filter((buzz) => !PlayerUtils.playersEqual(buzz.marker.player, player));
         if (this.wrongBuzzes.length === oldLength) {
             // Nothing left, don't make any changes
             return;
@@ -639,7 +639,7 @@ export class Cycle implements ICycle {
     }
 
     private removePlayerBuzzes(player: IPlayer): void {
-        this.removeBuzzes((event) => CompareUtils.playersEqual(player, event.marker.player));
+        this.removeBuzzes((event) => PlayerUtils.playersEqual(player, event.marker.player));
 
         this.tossupProtests = this.tossupProtests?.filter((protest) => protest.teamName !== player.teamName);
 

--- a/src/state/IPendingNewGame.ts
+++ b/src/state/IPendingNewGame.ts
@@ -3,13 +3,36 @@ import { IGameFormat } from "./IGameFormat";
 import { PacketState } from "./PacketState";
 import { Player } from "./TeamState";
 
-export type IPendingNewGame = IPendingManualNewGame | IPendingFromSheetsNewGame | IPendingQBJRegistrationNewGame;
+export type IPendingNewGame =
+    | IPendingManualNewGame
+    | IPendingFromTJSheetsNewGame
+    | IPendingFromUCSDSheetsNewGame
+    | IPendingQBJRegistrationNewGame;
 
 export interface IPendingManualNewGame extends IBasePendingNewGame {
+    manual: IPendingManualNewGameState;
+    type: PendingGameType.Manual;
+}
+
+export interface IPendingFromTJSheetsNewGame extends IBasePendingNewGame {
+    tjSheets: IPendingFromSheetsNewGameState;
+    type: PendingGameType.TJSheets;
+}
+
+export interface IPendingFromUCSDSheetsNewGame extends IBasePendingNewGame {
+    ucsdSheets: IPendingFromSheetsNewGameState;
+    type: PendingGameType.UCSDSheets;
+}
+
+export interface IPendingQBJRegistrationNewGame extends IBasePendingNewGame {
+    registration: IPendingQBJRegistrationNewGameState;
+    type: PendingGameType.QBJRegistration;
+}
+
+export interface IPendingManualNewGameState {
     firstTeamPlayers: Player[];
     secondTeamPlayers: Player[];
     cycles?: Cycle[];
-    type: PendingGameType.Manual;
 }
 
 export const enum PendingGameType {
@@ -19,23 +42,22 @@ export const enum PendingGameType {
     QBJRegistration,
 }
 
-export interface IPendingFromSheetsNewGame extends IBasePendingNewGame {
+export interface IPendingFromSheetsNewGameState {
     rostersUrl: string | undefined;
     playersFromRosters: Player[] | undefined;
     firstTeamPlayersFromRosters: Player[] | undefined;
     secondTeamPlayersFromRosters: Player[] | undefined;
-    type: PendingGameType.TJSheets | PendingGameType.UCSDSheets;
 }
 
-export interface IPendingQBJRegistrationNewGame extends IBasePendingNewGame {
+export interface IPendingQBJRegistrationNewGameState {
     players: Player[];
     firstTeamPlayers: Player[] | undefined;
     secondTeamPlayers: Player[] | undefined;
     cycles?: Cycle[];
-    type: PendingGameType.QBJRegistration;
 }
 
 interface IBasePendingNewGame {
     packet: PacketState;
     gameFormat: IGameFormat;
+    type: PendingGameType;
 }

--- a/src/state/NewGameValidator.ts
+++ b/src/state/NewGameValidator.ts
@@ -82,7 +82,7 @@ function atLeastOneStarter(players: Player[]): boolean {
 function atLeastOneCycleIfCyclesExist(pendingNewGame: IPendingNewGame): boolean {
     return (
         pendingNewGame.type !== PendingGameType.Manual ||
-        pendingNewGame.cycles == undefined ||
-        pendingNewGame.cycles.length > 0
+        pendingNewGame.manual.cycles == undefined ||
+        pendingNewGame.manual.cycles.length > 0
     );
 }

--- a/src/state/PendingNewGameUtils.ts
+++ b/src/state/PendingNewGameUtils.ts
@@ -1,12 +1,27 @@
+import { assertNever } from "@fluentui/react";
 import { IPendingNewGame, PendingGameType } from "./IPendingNewGame";
 import { Player } from "./TeamState";
 
 export function getPendingNewGamePlayers(pendingNewGame: IPendingNewGame): [Player[], Player[]] {
-    if (pendingNewGame.type === PendingGameType.Manual) {
-        return [pendingNewGame.firstTeamPlayers, pendingNewGame.secondTeamPlayers];
-    } else if (pendingNewGame.type === PendingGameType.QBJRegistration) {
-        return [pendingNewGame.firstTeamPlayers ?? [], pendingNewGame.secondTeamPlayers ?? []];
-    } else {
-        return [pendingNewGame.firstTeamPlayersFromRosters ?? [], pendingNewGame.secondTeamPlayersFromRosters ?? []];
+    switch (pendingNewGame.type) {
+        case PendingGameType.Manual:
+            return [pendingNewGame.manual.firstTeamPlayers, pendingNewGame.manual.secondTeamPlayers];
+        case PendingGameType.QBJRegistration:
+            return [
+                pendingNewGame.registration.firstTeamPlayers ?? [],
+                pendingNewGame.registration.secondTeamPlayers ?? [],
+            ];
+        case PendingGameType.TJSheets:
+            return [
+                pendingNewGame.tjSheets.firstTeamPlayersFromRosters ?? [],
+                pendingNewGame.tjSheets.secondTeamPlayersFromRosters ?? [],
+            ];
+        case PendingGameType.UCSDSheets:
+            return [
+                pendingNewGame.ucsdSheets.firstTeamPlayersFromRosters ?? [],
+                pendingNewGame.ucsdSheets.secondTeamPlayersFromRosters ?? [],
+            ];
+        default:
+            assertNever(pendingNewGame);
     }
 }

--- a/src/state/PlayerUtils.ts
+++ b/src/state/PlayerUtils.ts
@@ -1,0 +1,81 @@
+import { IPlayer, Player } from "./TeamState";
+
+export function playersEqual(player: IPlayer, other: IPlayer): boolean {
+    return player.name === other.name && player.teamName === other.teamName;
+}
+
+export function movePlayerBackward(players: Player[], player: Player): Player[] {
+    // Make a copy so that we don't overwrite the original array
+    players = [...players];
+
+    let nextTeammateIndex = -1;
+    for (let i = players.length - 1; i >= 0; i--) {
+        const currentPlayer: IPlayer = players[i];
+        if (player === currentPlayer) {
+            if (nextTeammateIndex === -1) {
+                // Current player is in front, we can't move them
+                return players;
+            }
+
+            players[i] = players[nextTeammateIndex];
+            players[nextTeammateIndex] = player;
+            return players;
+        }
+
+        if (players[i].teamName === player.teamName) {
+            nextTeammateIndex = i;
+        }
+    }
+
+    return players;
+}
+
+export function movePlayerForward(players: Player[], player: Player): Player[] {
+    // Make a copy so that we don't overwrite the original array
+    players = [...players];
+
+    let previousTeammateIndex = -1;
+    for (let i = 0; i < players.length; i++) {
+        const currentPlayer: IPlayer = players[i];
+        if (player === currentPlayer) {
+            if (previousTeammateIndex === -1) {
+                // Current player is in front, we can't move them
+                return players;
+            }
+
+            players[i] = players[previousTeammateIndex];
+            players[previousTeammateIndex] = player;
+            return players;
+        }
+
+        if (players[i].teamName === player.teamName) {
+            previousTeammateIndex = i;
+        }
+    }
+
+    return players;
+}
+
+export function movePlayerToIndex(players: Player[], player: Player, index: number): Player[] {
+    if (index < 0) {
+        return players;
+    }
+
+    const teamName: string = player.teamName;
+    let sameTeamCount = -1;
+    for (let i = 0; i < players.length; i++) {
+        const currentPlayer: IPlayer = players[i];
+        if (currentPlayer.teamName === teamName) {
+            sameTeamCount++;
+        }
+
+        if (sameTeamCount === index) {
+            let newPlayers = players.filter((p) => p !== player);
+            newPlayers = newPlayers.slice(0, i).concat(player).concat(newPlayers.slice(i));
+            return newPlayers;
+        }
+    }
+
+    // Index is beyond the number of players in the team. Treat it as a no-op
+    return players;
+}

--- a/src/state/ReorderPlayersDialogState.ts
+++ b/src/state/ReorderPlayersDialogState.ts
@@ -1,4 +1,6 @@
 import { makeAutoObservable } from "mobx";
+
+import * as PlayerUtils from "./PlayerUtils";
 import { Player } from "./TeamState";
 
 export class ReorderPlayersDialogState {
@@ -18,68 +20,14 @@ export class ReorderPlayersDialogState {
     }
 
     public movePlayerBackward(player: Player): void {
-        let nextTeammateIndex = -1;
-        for (let i = this.players.length - 1; i >= 0; i--) {
-            const currentPlayer: Player = this.players[i];
-            if (player === currentPlayer) {
-                if (nextTeammateIndex === -1) {
-                    // Current player is in front, we can't move them
-                    return;
-                }
-
-                this.players[i] = this.players[nextTeammateIndex];
-                this.players[nextTeammateIndex] = player;
-                return;
-            }
-
-            if (this.players[i].teamName === player.teamName) {
-                nextTeammateIndex = i;
-            }
-        }
+        this.players = PlayerUtils.movePlayerBackward(this.players, player);
     }
 
     public movePlayerForward(player: Player): void {
-        let previousTeammateIndex = -1;
-        for (let i = 0; i < this.players.length; i++) {
-            const currentPlayer: Player = this.players[i];
-            if (player === currentPlayer) {
-                if (previousTeammateIndex === -1) {
-                    // Current player is in front, we can't move them
-                    return;
-                }
-
-                this.players[i] = this.players[previousTeammateIndex];
-                this.players[previousTeammateIndex] = player;
-                return;
-            }
-
-            if (this.players[i].teamName === player.teamName) {
-                previousTeammateIndex = i;
-            }
-        }
+        this.players = PlayerUtils.movePlayerForward(this.players, player);
     }
 
     public movePlayerToIndex(player: Player, index: number): void {
-        if (index < 0) {
-            return;
-        }
-
-        const teamName: string = player.teamName;
-        let sameTeamCount = -1;
-        for (let i = 0; i < this.players.length; i++) {
-            const currentPlayer: Player = this.players[i];
-            if (currentPlayer.teamName === teamName) {
-                sameTeamCount++;
-            }
-
-            if (sameTeamCount === index) {
-                let newPlayers = this.players.filter((p) => p !== player);
-                newPlayers = newPlayers.slice(0, i).concat(player).concat(newPlayers.slice(i));
-                this.players = newPlayers;
-                return;
-            }
-        }
-
-        // Index is beyond the number of players in the team. Treat it as a no-op
+        this.players = PlayerUtils.movePlayerToIndex(this.players, player, index);
     }
 }

--- a/tests/NewGameValidatorTests.ts
+++ b/tests/NewGameValidatorTests.ts
@@ -71,118 +71,146 @@ describe("NewGameValidatorTests", () => {
 
         it("No players in first team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("No players in second team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [],
+                },
             });
         });
         it("Only empty names in first team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("Only empty names in second team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("", "2", true)],
+                },
             });
         });
         it("Same player names in first team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true), new Player("aa", "1", true), new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [
+                        new Player("a", "1", true),
+                        new Player("aa", "1", true),
+                        new Player("a", "1", true),
+                    ],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("Same player names in second team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [
-                    new Player("b", "2", true),
-                    new Player("bb", "2", true),
-                    new Player("b", "2", true),
-                ],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [
+                        new Player("b", "2", true),
+                        new Player("bb", "2", true),
+                        new Player("b", "2", true),
+                    ],
+                },
             });
         });
         it("No starters in first team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", false)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", false)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("No starters in second team", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", false)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", false)],
+                },
             });
         });
         it("No tossups in packet", () => {
             assertNewGameIsInvalid({
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: new PacketState(),
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("Empty cycles array", () => {
             assertNewGameIsInvalid({
-                cycles: [],
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    cycles: [],
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             });
         });
         it("Valid game (Manual)", () => {
             const newGame: IPendingNewGame = {
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             };
             const result: boolean = NewGameValidator.isValid(newGame);
             expect(result).to.be.true;
         });
         it("Valid game (Manual with cycles)", () => {
             const newGame: IPendingNewGame = {
-                cycles: defaultPacket.tossups.map(() => new Cycle()),
-                firstTeamPlayers: [new Player("a", "1", true)],
-                secondTeamPlayers: [new Player("b", "2", true)],
                 packet: defaultPacket,
                 type: PendingGameType.Manual,
                 gameFormat: GameFormats.UndefinedGameFormat,
+                manual: {
+                    cycles: defaultPacket.tossups.map(() => new Cycle()),
+                    firstTeamPlayers: [new Player("a", "1", true)],
+                    secondTeamPlayers: [new Player("b", "2", true)],
+                },
             };
             const result: boolean = NewGameValidator.isValid(newGame);
             expect(result).to.be.true;

--- a/tests/SheetsTests.ts
+++ b/tests/SheetsTests.ts
@@ -4,7 +4,7 @@ import * as GameFormats from "src/state/GameFormats";
 import * as Sheets from "src/sheets/Sheets";
 import { ISheetsApi, ISheetsBatchGetResponse, ISheetsGetResponse } from "src/sheets/ISheetsApi";
 import { AppState } from "src/state/AppState";
-import { IPendingFromSheetsNewGame, IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
+import { IPendingFromSheetsNewGameState, IPendingNewGame, PendingGameType } from "src/state/IPendingNewGame";
 import { ExportState, LoadingState, SheetType } from "src/state/SheetState";
 import { IStatus } from "src/IStatus";
 import { Player } from "src/state/TeamState";
@@ -1298,7 +1298,7 @@ describe("SheetsTests", () => {
             sheetType: SheetType,
             expectedPendingGameType: PendingGameType,
             cells: string[][],
-            verifyPlayers: (pendingNewGame: IPendingFromSheetsNewGame, playerNamesFromRosters: string[]) => void
+            verifyPlayers: (pendingNewGame: IPendingNewGame, playerNamesFromRosters: string[]) => void
         ) => {
             const appState: AppState = createAppStateForRosters(sheetType, expectedPendingGameType);
 
@@ -1336,7 +1336,9 @@ describe("SheetsTests", () => {
             expect(appState.uiState.pendingNewGame.type).to.equal(expectedPendingGameType);
 
             const pendingNewGame: IPendingNewGame = appState.uiState.pendingNewGame;
-            const playerNamesFromRosters: string[] = (pendingNewGame.playersFromRosters ?? []).map(
+            const sheetsState: IPendingFromSheetsNewGameState =
+                pendingNewGame.type === PendingGameType.TJSheets ? pendingNewGame.tjSheets : pendingNewGame.ucsdSheets;
+            const playerNamesFromRosters: string[] = (sheetsState.playersFromRosters ?? []).map(
                 (player) => player.name
             );
 
@@ -1367,11 +1369,16 @@ describe("SheetsTests", () => {
                         expect(playerNamesFromRosters).to.contain(name);
                     }
 
+                    if (pendingNewGame.type !== PendingGameType.TJSheets) {
+                        assert.fail("Should be TJSheets");
+                        return;
+                    }
+
                     expect(
-                        pendingNewGame.firstTeamPlayersFromRosters?.map((player) => player.name) ?? []
+                        pendingNewGame.tjSheets.firstTeamPlayersFromRosters?.map((player) => player.name) ?? []
                     ).to.deep.equal(firstTeamPlayers);
                     expect(
-                        pendingNewGame.secondTeamPlayersFromRosters?.map((player) => player.name) ?? []
+                        pendingNewGame.tjSheets.secondTeamPlayersFromRosters?.map((player) => player.name) ?? []
                     ).to.deep.equal(secondTeamPlayers);
                 }
             );
@@ -1390,11 +1397,16 @@ describe("SheetsTests", () => {
                         expect(playerNamesFromRosters).to.contain(name);
                     }
 
+                    if (pendingNewGame.type !== PendingGameType.UCSDSheets) {
+                        assert.fail("Should be UCSDSheets");
+                        return;
+                    }
+
                     expect(
-                        pendingNewGame.firstTeamPlayersFromRosters?.map((player) => player.name) ?? []
+                        pendingNewGame.ucsdSheets.firstTeamPlayersFromRosters?.map((player) => player.name) ?? []
                     ).to.deep.equal(firstRow.slice(1));
                     expect(
-                        pendingNewGame.secondTeamPlayersFromRosters?.map((player) => player.name) ?? []
+                        pendingNewGame.ucsdSheets.secondTeamPlayersFromRosters?.map((player) => player.name) ?? []
                     ).to.deep.equal(secondRow.slice(1));
                 }
             );


### PR DESCRIPTION
- Allow players from sheets/registration file to be re-ordered in the New Game dialog (#230)
- Remember the rosters from sheets/registration file when starting a new game (#234)
    - Doesn't persist between page refreshes
- Fix bug where players were shared between sheets/registration and manual new games, letting you edit player names for the sheets/registration rosters (#235)
- Bump version to 1.23.0