### PR TITLE
Merged PR 298: v1.26.0 - Rename teams, black pronunciation guides, styling fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.25.0",
+    "version": "1.26.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/FormattedText.tsx
+++ b/src/components/FormattedText.tsx
@@ -72,6 +72,7 @@ const useStyles = memoizeFunction(
         mergeStyleSets({
             text: {
                 display: "inline",
+                textDecorationSkipInk: "none",
             },
             pronunciationGuide: {
                 // Don't override the color if it's disabled; the container has that responsibility

--- a/src/components/ModalDialogContainer.tsx
+++ b/src/components/ModalDialogContainer.tsx
@@ -17,6 +17,7 @@ import { ScoresheetDialog } from "./dialogs/ScoresheetDialog";
 import { StateContext } from "../contexts/StateContext";
 import { AppState } from "../state/AppState";
 import { ModalVisibilityStatus } from "../state/ModalVisibilityStatus";
+import { RenameTeamDialog } from "./dialogs/RenameTeamDialog";
 
 export const ModalDialogContainer = observer(function ModalDialogContainer() {
     // The Protest dialogs aren't here because they require extra information
@@ -38,6 +39,7 @@ export const ModalDialogContainer = observer(function ModalDialogContainer() {
             <MessageDialog />
             <NewGameDialog />
             <RenamePlayerDialog />
+            <RenameTeamDialog />
             <ReorderPlayerDialog />
             <ScoresheetDialog />
         </>

--- a/src/components/dialogs/AddPlayerDialog.tsx
+++ b/src/components/dialogs/AddPlayerDialog.tsx
@@ -1,57 +1,20 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import {
-    Dropdown,
-    TextField,
-    IDropdownOption,
-    IDialogContentProps,
-    DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
-    DialogFooter,
-    PrimaryButton,
-    DefaultButton,
-} from "@fluentui/react";
+import { Dropdown, TextField, IDropdownOption, DialogFooter, PrimaryButton, DefaultButton } from "@fluentui/react";
 
 import * as AddPlayerDialogController from "../../components/dialogs/AddPlayerDialogController";
 import { IPlayer } from "../../state/TeamState";
 import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Add Player",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const AddPlayerDialog = observer(function AddPlayerDialog(): JSX.Element {
-    const appState: AppState = React.useContext(StateContext);
-
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.AddPlayer}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Add Player"
+            visibilityStatus={ModalVisibilityStatus.AddPlayer}
             onDismiss={AddPlayerDialogController.hideDialog}
         >
             <AddPlayerDialogBody />
@@ -59,7 +22,7 @@ export const AddPlayerDialog = observer(function AddPlayerDialog(): JSX.Element 
                 <PrimaryButton text="Add" onClick={AddPlayerDialogController.addPlayer} />
                 <DefaultButton text="Cancel" onClick={AddPlayerDialogController.hideDialog} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/AddQuestionsDialog.tsx
+++ b/src/components/dialogs/AddQuestionsDialog.tsx
@@ -1,53 +1,20 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import {
-    IDialogContentProps,
-    DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
-    DialogFooter,
-    PrimaryButton,
-    DefaultButton,
-} from "@fluentui/react";
+import { DialogFooter, PrimaryButton, DefaultButton } from "@fluentui/react";
 
 import * as AddQuestionsDialogController from "./AddQuestionsDialogController";
 import { AppState } from "../../state/AppState";
 import { PacketLoader } from "../PacketLoader";
 import { StateContext } from "../../contexts/StateContext";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Add Questions",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const AddQuestionsDialog = observer(function AddQuestionsDialog(): JSX.Element {
-    const appState: AppState = React.useContext(StateContext);
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.AddQuestions}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Add Questions"
+            visibilityStatus={ModalVisibilityStatus.AddQuestions}
             onDismiss={AddQuestionsDialogController.cancel}
         >
             <AddQuestionsDialogBody />
@@ -55,7 +22,7 @@ export const AddQuestionsDialog = observer(function AddQuestionsDialog(): JSX.El
                 <PrimaryButton text="Load" onClick={AddQuestionsDialogController.commit} />
                 <DefaultButton text="Cancel" onClick={AddQuestionsDialogController.cancel} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/BonusProtestDialog.tsx
+++ b/src/components/dialogs/BonusProtestDialog.tsx
@@ -36,10 +36,10 @@ export const BonusProtestDialog = observer(function BonusProtestDialog(props: IB
         <ProtestDialogBase
             appState={props.appState}
             givenAnswer={protestEvent.givenAnswer}
-            hidden={props.appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.BonusProtest}
             hideDialog={BonusProtestDialogController.cancel}
             onSubmit={submitHandler}
             reason={protestEvent.reason}
+            visibilityStatus={ModalVisibilityStatus.BonusProtest}
         >
             {children}
         </ProtestDialogBase>

--- a/src/components/dialogs/CustomizeGameFormatDialog.tsx
+++ b/src/components/dialogs/CustomizeGameFormatDialog.tsx
@@ -3,9 +3,6 @@ import { observer } from "mobx-react-lite";
 import {
     IDialogContentProps,
     DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
     DialogFooter,
     PrimaryButton,
     DefaultButton,
@@ -28,6 +25,7 @@ import { StateContext } from "../../contexts/StateContext";
 import { GameFormatPicker } from "../GameFormatPicker";
 import { SheetType } from "../../state/SheetState";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
+import { ModalDialog } from "./ModalDialog";
 
 const content: IDialogContentProps = {
     type: DialogType.normal,
@@ -41,24 +39,6 @@ const content: IDialogContentProps = {
             marginBottom: 30,
         },
     },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    styles: {
-        main: {
-            // To have max width respected normally, we'd need to pass in an IDialogStyleProps, but it ridiculously
-            // requires you to pass in an entire theme to modify the max width. We could also use a modal, but that
-            // requires building much of what Dialogs offer easily (close buttons, footer for buttons)
-            minWidth: "30vw !important",
-        },
-    },
-    topOffsetFixed: true,
 };
 
 const pivotStyles: Partial<IPivotStyles> = {
@@ -76,10 +56,10 @@ export const CustomizeGameFormatDialog = observer(function CustomizeGameFormatDi
     const cancelHandler = React.useCallback(() => CustomizeGameFormatDialogController.cancel(appState), [appState]);
 
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.CustomizeGameFormat}
+        <ModalDialog
+            title="Customize Game Format"
+            visibilityStatus={ModalVisibilityStatus.CustomizeGameFormat}
             dialogContentProps={content}
-            modalProps={modalProps}
             onDismiss={cancelHandler}
         >
             <CustomizeGameFormatDialogBody />
@@ -87,7 +67,7 @@ export const CustomizeGameFormatDialog = observer(function CustomizeGameFormatDi
                 <PrimaryButton text="Save" onClick={submitHandler} />
                 <DefaultButton text="Cancel" onClick={cancelHandler} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/ExportToSheetsDialog.tsx
+++ b/src/components/dialogs/ExportToSheetsDialog.tsx
@@ -2,11 +2,6 @@ import * as React from "react";
 import { observer } from "mobx-react-lite";
 import {
     TextField,
-    IDialogContentProps,
-    DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
     DialogFooter,
     PrimaryButton,
     DefaultButton,
@@ -28,29 +23,7 @@ import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { RoundSelector } from "../RoundSelector";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Export to Sheets",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 const warningIconStyles: IIconStyles = {
     root: {
@@ -110,16 +83,15 @@ export const ExportToSheetsDialog = observer(function ExportToSheetsDialog(): JS
     }
 
     return (
-        <Dialog
-            hidden={uiState.dialogState.visibleDialog !== ModalVisibilityStatus.ExportToSheets}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Export to Sheets"
+            visibilityStatus={ModalVisibilityStatus.ExportToSheets}
             maxWidth="40vw"
             onDismiss={cancelHandler}
         >
             <ExportSettingsDialogBody />
             {footer}
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/FontDialog.tsx
+++ b/src/components/dialogs/FontDialog.tsx
@@ -1,14 +1,9 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 import {
-    Dialog,
     DialogFooter,
     PrimaryButton,
     DefaultButton,
-    ContextualMenu,
-    DialogType,
-    IDialogContentProps,
-    IModalProps,
     SpinButton,
     Dropdown,
     IDropdownOption,
@@ -24,29 +19,7 @@ import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { FontDialogState } from "../../state/FontDialogState";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Font",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 const defaultFont = "Segoe UI";
 
@@ -73,13 +46,10 @@ const maximumFontSize = 40;
 const stackTokens: Partial<IStackTokens> = { childrenGap: 10 };
 
 export const FontDialog = observer(function FontDialog(): JSX.Element {
-    const appState: AppState = React.useContext(StateContext);
-
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.Font}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Font"
+            visibilityStatus={ModalVisibilityStatus.Font}
             maxWidth="40vw"
             onDismiss={FontDialogController.cancel}
         >
@@ -88,7 +58,7 @@ export const FontDialog = observer(function FontDialog(): JSX.Element {
                 <PrimaryButton text="OK" onClick={FontDialogController.update} />
                 <DefaultButton text="Cancel" onClick={FontDialogController.cancel} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 
@@ -154,6 +124,11 @@ const FontDialogBody = observer(function FontDialogBody(): JSX.Element {
             key: "burgundy",
             text: "Burgundy",
             data: "#770077",
+        },
+        {
+            key: "black",
+            text: "Black",
+            data: "#000000",
         },
         {
             key: "darkGray",

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -1,54 +1,19 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import {
-    Dialog,
-    DialogFooter,
-    PrimaryButton,
-    ContextualMenu,
-    DialogType,
-    IDialogContentProps,
-    IModalProps,
-    Label,
-    Link,
-    Stack,
-    StackItem,
-} from "@fluentui/react";
+import { DialogFooter, PrimaryButton, Label, Link, Stack, StackItem } from "@fluentui/react";
 import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Help",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 export const HelpDialog = observer(function HelpDialog(): JSX.Element {
     const appState: AppState = React.useContext(StateContext);
     const closeHandler = React.useCallback(() => hideDialog(appState), [appState]);
 
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.Help}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Help"
+            visibilityStatus={ModalVisibilityStatus.Help}
             maxWidth="30vw"
             onDismiss={closeHandler}
         >
@@ -56,7 +21,7 @@ export const HelpDialog = observer(function HelpDialog(): JSX.Element {
             <DialogFooter>
                 <PrimaryButton text="Close" onClick={closeHandler} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/ImportGameDialog.tsx
+++ b/src/components/dialogs/ImportGameDialog.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 import {
-    Dialog,
     DialogFooter,
     PrimaryButton,
     DefaultButton,
     Label,
-    ContextualMenu,
-    DialogType,
-    IDialogContentProps,
-    IModalProps,
     Stack,
     ILabelStyles,
     StackItem,
@@ -29,29 +24,7 @@ import { Cycle, ICycle } from "../../state/Cycle";
 import { IPendingNewGame, PendingGameType } from "../../state/IPendingNewGame";
 import { StateContext } from "../../contexts/StateContext";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Import Game",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 const stackTokens: IStackTokens = { childrenGap: 10 };
 
@@ -61,18 +34,13 @@ export const ImportGameDialog = observer(function ImportGameDialog(): JSX.Elemen
     const submitHandler = React.useCallback(() => onSubmit(appState), [appState]);
 
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.ImportGame}
-            dialogContentProps={content}
-            modalProps={modalProps}
-            onDismiss={cancelHandler}
-        >
+        <ModalDialog title="Import Game" visibilityStatus={ModalVisibilityStatus.ImportGame} onDismiss={cancelHandler}>
             <ImportGameDialogBody />
             <DialogFooter>
                 <PrimaryButton text="Import Game" onClick={submitHandler} />
                 <DefaultButton text="Cancel" onClick={cancelHandler} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/MessageDialog.tsx
+++ b/src/components/dialogs/MessageDialog.tsx
@@ -1,31 +1,12 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import {
-    Dialog,
-    DialogFooter,
-    PrimaryButton,
-    ContextualMenu,
-    DialogType,
-    IDialogContentProps,
-    IModalProps,
-    Label,
-    DefaultButton,
-} from "@fluentui/react";
+import { DialogFooter, PrimaryButton, Label, DefaultButton } from "@fluentui/react";
 
 import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { IMessageDialogState, MessageDialogType } from "../../state/IMessageDialogState";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 export const MessageDialog = observer(function MessageDialog(): JSX.Element {
     const appState: AppState = React.useContext(StateContext);
@@ -43,13 +24,6 @@ export const MessageDialog = observer(function MessageDialog(): JSX.Element {
         }
 
         hideDialog(appState);
-    };
-
-    const dialogContent: IDialogContentProps = {
-        type: DialogType.normal,
-        title: messageDialog.title,
-        closeButtonAriaLabel: "Close",
-        showCloseButton: true,
     };
 
     const noButton: JSX.Element | undefined =
@@ -74,10 +48,9 @@ export const MessageDialog = observer(function MessageDialog(): JSX.Element {
     const okButtonText = messageDialog.type === MessageDialogType.YesNocCancel ? "Yes" : "OK";
 
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.Message}
-            dialogContentProps={dialogContent}
-            modalProps={modalProps}
+        <ModalDialog
+            title={messageDialog.title}
+            visibilityStatus={ModalVisibilityStatus.Message}
             maxWidth="30vw"
             onDismiss={closeHandler}
         >
@@ -87,7 +60,7 @@ export const MessageDialog = observer(function MessageDialog(): JSX.Element {
                 {noButton}
                 {cancelButton}
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/ModalDialog.tsx
+++ b/src/components/dialogs/ModalDialog.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { ContextualMenu, Dialog, DialogType, IDialogContentProps, IDialogProps, IModalProps } from "@fluentui/react";
+import { observer } from "mobx-react-lite";
+
+import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
+import { StateContext } from "../../contexts/StateContext";
+import { AppState } from "../../state/AppState";
+
+const modalProps: IModalProps = {
+    isBlocking: false,
+    dragOptions: {
+        moveMenuItemText: "Move",
+        closeMenuItemText: "Close",
+        menu: ContextualMenu,
+    },
+    topOffsetFixed: true,
+};
+
+export const ModalDialog = observer(function ModalDialog(
+    props: React.PropsWithChildren<IModalDialogProps>
+): JSX.Element {
+    const appState: AppState = React.useContext(StateContext);
+
+    const content: IDialogContentProps = {
+        type: DialogType.normal,
+        title: props.title,
+        closeButtonAriaLabel: "Close",
+        showCloseButton: true,
+        styles: {
+            innerContent: {
+                display: "flex",
+                flexDirection: "column",
+            },
+        },
+    };
+
+    return (
+        <Dialog
+            dialogContentProps={content}
+            modalProps={modalProps}
+            hidden={appState.uiState.dialogState.visibleDialog !== props.visibilityStatus}
+            {...props}
+        >
+            {props.children}
+        </Dialog>
+    );
+});
+
+export interface IModalDialogProps extends IDialogProps {
+    title: string;
+    visibilityStatus: ModalVisibilityStatus;
+}

--- a/src/components/dialogs/ProtestDialogBase.tsx
+++ b/src/components/dialogs/ProtestDialogBase.tsx
@@ -1,29 +1,12 @@
 import * as React from "react";
-import { Dialog, DialogFooter, IDialogContentProps, DialogType } from "@fluentui/react/lib/Dialog";
-import { IModalProps } from "@fluentui/react/lib/Modal";
-import { ContextualMenu } from "@fluentui/react/lib/ContextualMenu";
+import { DialogFooter } from "@fluentui/react/lib/Dialog";
 import { PrimaryButton, DefaultButton } from "@fluentui/react/lib/Button";
 import { observer } from "mobx-react-lite";
 
 import { TextField } from "@fluentui/react/lib/TextField";
 import { AppState } from "../../state/AppState";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Add Protest",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
+import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
 
 export const ProtestDialogBase = observer(function ProtestDialogBase(
     props: React.PropsWithChildren<IProtestDialogBaseProps>
@@ -42,7 +25,7 @@ export const ProtestDialogBase = observer(function ProtestDialogBase(
     const cancelHandler = React.useCallback(() => onCancel(props), [props]);
 
     return (
-        <Dialog hidden={props.hidden} dialogContentProps={content} modalProps={modalProps} onDismiss={cancelHandler}>
+        <ModalDialog title="Add Protest" visibilityStatus={props.visibilityStatus} onDismiss={cancelHandler}>
             {props.children}
             <TextField
                 label="Given answer"
@@ -61,7 +44,7 @@ export const ProtestDialogBase = observer(function ProtestDialogBase(
                 <PrimaryButton text="OK" onClick={submitHandler} />
                 <DefaultButton text="Cancel" onClick={cancelHandler} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 
@@ -78,7 +61,7 @@ export interface IProtestDialogBaseProps {
     appState: AppState;
     autoFocusOnGivenAnswer?: boolean;
     givenAnswer: string | undefined;
-    hidden: boolean;
+    visibilityStatus: ModalVisibilityStatus;
     reason: string;
 
     hideDialog: () => void;

--- a/src/components/dialogs/RenamePlayerDialog.tsx
+++ b/src/components/dialogs/RenamePlayerDialog.tsx
@@ -1,17 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import {
-    TextField,
-    IDialogContentProps,
-    DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
-    DialogFooter,
-    PrimaryButton,
-    DefaultButton,
-    Label,
-} from "@fluentui/react";
+import { TextField, DialogFooter, PrimaryButton, DefaultButton, Label } from "@fluentui/react";
 
 import * as RenamePlayerDialogController from "../../components/dialogs/RenamePlayerDialogController";
 import { Player } from "../../state/TeamState";
@@ -19,38 +8,13 @@ import { AppState } from "../../state/AppState";
 import { StateContext } from "../../contexts/StateContext";
 import { RenamePlayerDialogState } from "../../state/RenamePlayerDialogState";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Rename Player",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 export const RenamePlayerDialog = observer(function RenamePlayerDialog(): JSX.Element {
-    const appState: AppState = React.useContext(StateContext);
-
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.RenamePlayer}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Rename Player"
+            visibilityStatus={ModalVisibilityStatus.RenamePlayer}
             onDismiss={RenamePlayerDialogController.hideDialog}
         >
             <RenamePlayerDialogBody />
@@ -58,7 +22,7 @@ export const RenamePlayerDialog = observer(function RenamePlayerDialog(): JSX.El
                 <PrimaryButton text="OK" onClick={RenamePlayerDialogController.renamePlayer} />
                 <DefaultButton text="Cancel" onClick={RenamePlayerDialogController.hideDialog} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/RenameTeamDialog.tsx
+++ b/src/components/dialogs/RenameTeamDialog.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { observer } from "mobx-react-lite";
+import {
+    TextField,
+    DialogFooter,
+    PrimaryButton,
+    DefaultButton,
+    Dropdown,
+    Stack,
+    StackItem,
+    IDropdownOption,
+} from "@fluentui/react";
+
+import * as RenameTeamDialogController from "./RenameTeamDialogController";
+import { AppState } from "../../state/AppState";
+import { StateContext } from "../../contexts/StateContext";
+import { RenameTeamDialogState } from "../../state/RenameTeamDialogState";
+import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
+import { ModalDialog } from "./ModalDialog";
+
+export const RenameTeamDialog = observer(function RenameTeamDialog(): JSX.Element {
+    return (
+        <ModalDialog
+            title="Rename Team"
+            visibilityStatus={ModalVisibilityStatus.RenameTeam}
+            onDismiss={RenameTeamDialogController.hideDialog}
+        >
+            <RenameTeamDialogBody />
+            <DialogFooter>
+                <PrimaryButton text="OK" onClick={RenameTeamDialogController.renameTeam} />
+                <DefaultButton text="Cancel" onClick={RenameTeamDialogController.hideDialog} />
+            </DialogFooter>
+        </ModalDialog>
+    );
+});
+
+const RenameTeamDialogBody = observer(function RenameTeamDialogBody(): JSX.Element {
+    const appState: AppState = React.useContext(StateContext);
+
+    const teamChangeHandler = React.useCallback((ev: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+        if (option?.text != undefined) {
+            RenameTeamDialogController.changeTeam(option.text);
+        }
+    }, []);
+
+    const renameTeamDialog: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
+    if (renameTeamDialog === undefined) {
+        return <></>;
+    }
+
+    const teamOptions: IDropdownOption[] = appState.game.teamNames.map((teamName, index) => {
+        return {
+            key: index,
+            text: teamName,
+            selected: renameTeamDialog.teamName === teamName,
+        };
+    });
+
+    return (
+        <Stack>
+            <StackItem>
+                <Dropdown label="Team" options={teamOptions} onChange={teamChangeHandler} />
+            </StackItem>
+            <StackItem>
+                <TextField
+                    autoFocus={true}
+                    label="Name"
+                    value={renameTeamDialog.newName}
+                    required={true}
+                    onChange={onNameChange}
+                    onGetErrorMessage={RenameTeamDialogController.validate}
+                    validateOnFocusOut={true}
+                    validateOnLoad={false}
+                />
+            </StackItem>
+        </Stack>
+    );
+});
+
+function onNameChange(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) {
+    RenameTeamDialogController.changeNewName(newValue ?? "");
+}

--- a/src/components/dialogs/RenameTeamDialogController.ts
+++ b/src/components/dialogs/RenameTeamDialogController.ts
@@ -1,0 +1,79 @@
+import { AppState } from "../../state/AppState";
+import { GameState } from "../../state/GameState";
+import { RenameTeamDialogState } from "../../state/RenameTeamDialogState";
+
+export function renameTeam(): void {
+    const appState: AppState = AppState.instance;
+    const game: GameState = appState.game;
+    const renameDialogState: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
+    if (renameDialogState == undefined) {
+        return;
+    }
+
+    renameDialogState.clearErrorMessage();
+
+    const errorMessage: string | undefined = validate();
+    if (errorMessage != undefined) {
+        renameDialogState.setErrorMessage(errorMessage);
+        return;
+    }
+
+    const succeeded: boolean = game.tryUpdateTeamName(renameDialogState.teamName, renameDialogState.newName);
+
+    if (!succeeded) {
+        renameDialogState.setErrorMessage("Couldn't rename the team. Make sure the name is unique and try again.");
+        return;
+    }
+
+    hideDialog();
+}
+
+export function changeNewName(newName: string): void {
+    const appState: AppState = AppState.instance;
+    const renameTeamDialog: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
+    if (renameTeamDialog == undefined) {
+        return;
+    }
+
+    renameTeamDialog.setName(newName);
+}
+
+export function changeTeam(teamName: string): void {
+    const appState: AppState = AppState.instance;
+    const renameTeamDialog: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
+    if (renameTeamDialog == undefined) {
+        return;
+    }
+
+    // Reset the new name to the team name so that it's similar
+    renameTeamDialog.setTeam(teamName);
+    renameTeamDialog.setName(teamName);
+}
+
+export function validate(): string | undefined {
+    const appState: AppState = AppState.instance;
+    const renameTeamDialog: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
+    if (renameTeamDialog == undefined) {
+        return "Dialog is closed";
+    }
+
+    if (renameTeamDialog.newName === renameTeamDialog.teamName) {
+        // We can rename the team to itself
+        return undefined;
+    }
+
+    if (renameTeamDialog.newName == undefined || renameTeamDialog.newName.trim() === "") {
+        return "Name cannot be blank";
+    }
+
+    if (appState.game.teamNames.indexOf(renameTeamDialog.newName) >= 0) {
+        return "Team name already exists";
+    }
+
+    return undefined;
+}
+
+export function hideDialog(): void {
+    const appState: AppState = AppState.instance;
+    appState.uiState.dialogState.hideRenameTeamDialog();
+}

--- a/src/components/dialogs/ReorderPlayerDialog.tsx
+++ b/src/components/dialogs/ReorderPlayerDialog.tsx
@@ -3,11 +3,6 @@ import { observer } from "mobx-react-lite";
 import {
     Dropdown,
     IDropdownOption,
-    IDialogContentProps,
-    DialogType,
-    IModalProps,
-    ContextualMenu,
-    Dialog,
     DialogFooter,
     PrimaryButton,
     DefaultButton,
@@ -24,41 +19,16 @@ import { StateContext } from "../../contexts/StateContext";
 import { ReorderPlayersDialogState } from "../../state/ReorderPlayersDialogState";
 import { PlayerRoster } from "../PlayerRoster";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Reorder Players",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 const dialogBodyTokens: IStackTokens = { childrenGap: 10 };
 
 // TODO: Look into making a DefaultDialog, which handles the footers and default props
 export const ReorderPlayerDialog = observer(function ReorderPlayerDialog(): JSX.Element {
-    const appState: AppState = React.useContext(StateContext);
-
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.ReorderPlayers}
-            dialogContentProps={content}
-            modalProps={modalProps}
+        <ModalDialog
+            title="Reorder Players"
+            visibilityStatus={ModalVisibilityStatus.ReorderPlayers}
             onDismiss={ReorderPlayersDialogController.hideDialog}
         >
             <ReorderPlayerDialogBody />
@@ -66,7 +36,7 @@ export const ReorderPlayerDialog = observer(function ReorderPlayerDialog(): JSX.
                 <PrimaryButton text="OK" onClick={ReorderPlayersDialogController.submit} />
                 <DefaultButton text="Cancel" onClick={ReorderPlayersDialogController.hideDialog} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/ScoresheetDialog.tsx
+++ b/src/components/dialogs/ScoresheetDialog.tsx
@@ -6,13 +6,8 @@ import * as PlayerUtils from "../../state/PlayerUtils";
 import { Cycle } from "../../state/Cycle";
 import { AppState } from "../../state/AppState";
 import {
-    Dialog,
     DialogFooter,
     PrimaryButton,
-    ContextualMenu,
-    DialogType,
-    IDialogContentProps,
-    IModalProps,
     Stack,
     StackItem,
     ITheme,
@@ -25,29 +20,7 @@ import { GameState } from "../../state/GameState";
 import { Player } from "../../state/TeamState";
 import { ITossupAnswerEvent } from "../../state/Events";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
-
-const content: IDialogContentProps = {
-    type: DialogType.normal,
-    title: "Scoresheet",
-    closeButtonAriaLabel: "Close",
-    showCloseButton: true,
-    styles: {
-        innerContent: {
-            display: "flex",
-            flexDirection: "column",
-        },
-    },
-};
-
-const modalProps: IModalProps = {
-    isBlocking: false,
-    dragOptions: {
-        moveMenuItemText: "Move",
-        closeMenuItemText: "Close",
-        menu: ContextualMenu,
-    },
-    topOffsetFixed: true,
-};
+import { ModalDialog } from "./ModalDialog";
 
 // Based on the scoresheet created by Ryan Rosenberg, like the one here: https://quizbowlstats.com/games/95741
 export const ScoresheetDialog = observer(function ScoresheetDialog(): JSX.Element {
@@ -55,18 +28,17 @@ export const ScoresheetDialog = observer(function ScoresheetDialog(): JSX.Elemen
     const closeDialog = React.useCallback(() => appState.uiState.dialogState.hideModalDialog(), [appState]);
 
     return (
-        <Dialog
-            hidden={appState.uiState.dialogState.visibleDialog !== ModalVisibilityStatus.Scoresheet}
+        <ModalDialog
+            title="Scoresheet"
+            visibilityStatus={ModalVisibilityStatus.Scoresheet}
             maxWidth="100vw"
-            dialogContentProps={content}
-            modalProps={modalProps}
             onDismiss={closeDialog}
         >
             <ScoresheetDialogBody appState={appState} />
             <DialogFooter>
                 <PrimaryButton text="Close" onClick={closeDialog} />
             </DialogFooter>
-        </Dialog>
+        </ModalDialog>
     );
 });
 

--- a/src/components/dialogs/TossupProtestDialog.tsx
+++ b/src/components/dialogs/TossupProtestDialog.tsx
@@ -24,10 +24,10 @@ export const TossupProtestDialog = observer(function TossupProtestDialog(
             appState={props.appState}
             autoFocusOnGivenAnswer={true}
             givenAnswer={uiState.pendingTossupProtestEvent.givenAnswer}
-            hidden={uiState.dialogState.visibleDialog !== ModalVisibilityStatus.TossupProtest}
             hideDialog={TossupProtestDialogController.cancel}
             onSubmit={submitHandler}
             reason={uiState.pendingTossupProtestEvent.reason}
+            visibilityStatus={ModalVisibilityStatus.TossupProtest}
         />
     );
 });

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -9,6 +9,7 @@ import { Player } from "./TeamState";
 import { ReorderPlayersDialogState } from "./ReorderPlayersDialogState";
 import { FontDialogState } from "./FontDialogState";
 import { ModalVisibilityStatus } from "./ModalVisibilityStatus";
+import { RenameTeamDialogState } from "./RenameTeamDialogState";
 
 export class DialogState {
     @ignore
@@ -27,6 +28,9 @@ export class DialogState {
     public renamePlayerDialog: RenamePlayerDialogState | undefined;
 
     @ignore
+    public renameTeamDialog: RenameTeamDialogState | undefined;
+
+    @ignore
     public reorderPlayersDialog: ReorderPlayersDialogState | undefined;
 
     @ignore
@@ -40,6 +44,7 @@ export class DialogState {
         this.fontDialog = undefined;
         this.messageDialog = undefined;
         this.renamePlayerDialog = undefined;
+        this.renameTeamDialog = undefined;
         this.reorderPlayersDialog = undefined;
         this.visibleDialog = ModalVisibilityStatus.None;
     }
@@ -79,6 +84,13 @@ export class DialogState {
     public hideRenamePlayerDialog(): void {
         this.renamePlayerDialog = undefined;
         if (this.visibleDialog === ModalVisibilityStatus.RenamePlayer) {
+            this.hideModalDialog();
+        }
+    }
+
+    public hideRenameTeamDialog(): void {
+        this.renameTeamDialog = undefined;
+        if (this.visibleDialog === ModalVisibilityStatus.RenameTeam) {
             this.hideModalDialog();
         }
     }
@@ -130,6 +142,11 @@ export class DialogState {
     public showRenamePlayerDialog(player: Player): void {
         this.renamePlayerDialog = new RenamePlayerDialogState(player);
         this.visibleDialog = ModalVisibilityStatus.RenamePlayer;
+    }
+
+    public showRenameTeamDialog(initialTeamName: string): void {
+        this.renameTeamDialog = new RenameTeamDialogState(initialTeamName);
+        this.visibleDialog = ModalVisibilityStatus.RenameTeam;
     }
 
     public showReorderPlayersDialog(players: Player[]): void {

--- a/src/state/ModalVisibilityStatus.ts
+++ b/src/state/ModalVisibilityStatus.ts
@@ -12,6 +12,7 @@ export const enum ModalVisibilityStatus {
     Message,
     NewGame,
     RenamePlayer,
+    RenameTeam,
     ReorderPlayers,
     Scoresheet,
     TossupProtest,

--- a/src/state/RenameTeamDialogState.ts
+++ b/src/state/RenameTeamDialogState.ts
@@ -1,0 +1,33 @@
+import { makeAutoObservable } from "mobx";
+
+export class RenameTeamDialogState {
+    public errorMessage: string | undefined;
+
+    public newName: string;
+
+    public teamName: string;
+
+    constructor(initialTeamName: string) {
+        makeAutoObservable(this);
+
+        this.errorMessage = undefined;
+        this.newName = initialTeamName;
+        this.teamName = initialTeamName;
+    }
+
+    public clearErrorMessage(): void {
+        this.errorMessage = undefined;
+    }
+
+    public setErrorMessage(errorMessage: string): void {
+        this.errorMessage = errorMessage;
+    }
+
+    public setName(newName: string): void {
+        this.newName = newName;
+    }
+
+    public setTeam(teamName: string): void {
+        this.teamName = teamName;
+    }
+}

--- a/tests/RenamePlayerDialogControllerTests.ts
+++ b/tests/RenamePlayerDialogControllerTests.ts
@@ -48,7 +48,7 @@ function initializeApp(player: Player | undefined = undefined): { appState: AppS
 
 function getRenamePlayerDialogState(appState: AppState): RenamePlayerDialogState {
     if (appState.uiState.dialogState.renamePlayerDialog == undefined) {
-        assert.fail("PendingNewPlayer should not be undefined");
+        assert.fail("RenamePlayerDialog should not be undefined");
     }
 
     return appState.uiState.dialogState.renamePlayerDialog;
@@ -168,8 +168,8 @@ describe("RenamePlayerDialogControllerTests", () => {
             expect(correctBuzz.marker.player.name).to.equal(name);
             expect(correctBuzz.marker.player.teamName).to.equal(originalPlayer.teamName);
 
-            const secondCycle = appState.game.cycles[2];
-            const playerLeaves: IPlayerLeavesEvent[] | undefined = secondCycle.playerLeaves;
+            const thirdCycle = appState.game.cycles[2];
+            const playerLeaves: IPlayerLeavesEvent[] | undefined = thirdCycle.playerLeaves;
             if (playerLeaves === undefined) {
                 assert.fail("Expected playerLeaves event in the third cycle");
             }

--- a/tests/RenameTeamDialogControllerTests.ts
+++ b/tests/RenameTeamDialogControllerTests.ts
@@ -1,0 +1,248 @@
+import { assert, expect } from "chai";
+
+import * as GameFormats from "src/state/GameFormats";
+import * as RenameTeamDialogController from "src/components/dialogs/RenameTeamDialogController";
+import { AppState } from "src/state/AppState";
+import {
+    IBonusProtestEvent,
+    IPlayerJoinsEvent,
+    IPlayerLeavesEvent,
+    ISubstitutionEvent,
+    ITossupAnswerEvent,
+    ITossupProtestEvent,
+} from "src/state/Events";
+import { GameState } from "src/state/GameState";
+import { PacketState, Tossup } from "src/state/PacketState";
+import { RenameTeamDialogState } from "src/state/RenameTeamDialogState";
+import { Player } from "src/state/TeamState";
+
+const defaultPacket: PacketState = new PacketState();
+defaultPacket.setTossups([
+    new Tossup("first q", "first a"),
+    new Tossup("second q", "second a"),
+    new Tossup("third q", "third a"),
+    new Tossup("fourth q", "fourth a"),
+]);
+
+const defaultTeamNames: string[] = ["First Team", "Team2"];
+
+function createDefaultExistingPlayers(): Player[] {
+    return [
+        new Player("Alex", defaultTeamNames[0], true),
+        new Player("Anna", defaultTeamNames[0], true),
+        new Player("Bob", defaultTeamNames[1], true),
+        new Player("Anna", defaultTeamNames[1], true),
+        new Player("Ashok", defaultTeamNames[0], false),
+    ];
+}
+
+function initializeApp(): AppState {
+    const gameState: GameState = new GameState();
+    gameState.loadPacket(defaultPacket);
+
+    const players: Player[] = createDefaultExistingPlayers();
+    gameState.addNewPlayers(players);
+
+    AppState.resetInstance();
+    const appState: AppState = AppState.instance;
+    appState.game = gameState;
+    appState.uiState.dialogState.showRenameTeamDialog(players[0].teamName);
+    return appState;
+}
+
+function getRenameTeamDialogState(appState: AppState): RenameTeamDialogState {
+    if (appState.uiState.dialogState.renameTeamDialog == undefined) {
+        assert.fail("RenameTeamDialog should not be undefined");
+    }
+
+    return appState.uiState.dialogState.renameTeamDialog;
+}
+
+describe("RenameTeamDialogControllerTests", () => {
+    it("changeNewName", () => {
+        const name = "New team name";
+        const appState: AppState = initializeApp();
+        RenameTeamDialogController.changeNewName(name);
+        const state: RenameTeamDialogState = getRenameTeamDialogState(appState);
+
+        expect(state.newName).to.equal(name);
+        expect(state.teamName).to.equal(defaultTeamNames[0]);
+        expect(state.errorMessage).to.be.undefined;
+    });
+    it("hideDialog", () => {
+        const appState: AppState = initializeApp();
+        RenameTeamDialogController.hideDialog();
+
+        expect(appState.uiState.dialogState.renameTeamDialog).to.be.undefined;
+    });
+    describe("validate", () => {
+        it("validate - non-empty name", () => {
+            initializeApp();
+            RenameTeamDialogController.changeNewName(" ");
+            const errorMessage: string | undefined = RenameTeamDialogController.validate();
+            expect(errorMessage).to.not.be.undefined;
+        });
+        it("validate - duplicate name", () => {
+            initializeApp();
+            RenameTeamDialogController.changeNewName(defaultTeamNames[1]);
+            const errorMessage: string | undefined = RenameTeamDialogController.validate();
+            expect(errorMessage).to.not.be.undefined;
+        });
+        it("validate - new name", () => {
+            initializeApp();
+            RenameTeamDialogController.changeNewName("Newbie");
+            const errorMessage: string | undefined = RenameTeamDialogController.validate();
+            expect(errorMessage).to.be.undefined;
+        });
+    });
+    describe("renameTeam", () => {
+        it("renameTeam succeeds", () => {
+            const name = "New Team";
+            const appState: AppState = initializeApp();
+            const player: Player = appState.game.players[0];
+
+            appState.game.cycles[0].addWrongBuzz(
+                {
+                    player: player,
+                    points: -5,
+                    position: 10,
+                },
+                0,
+                GameFormats.UndefinedGameFormat
+            );
+
+            appState.game.cycles[0].addTossupProtest(player.teamName, 0, 10, "Some answer", "It was right");
+
+            appState.game.cycles[1].addCorrectBuzz(
+                {
+                    player: player,
+                    points: 15,
+                    position: 11,
+                },
+                0,
+                GameFormats.UndefinedGameFormat,
+                0,
+                3
+            );
+
+            appState.game.cycles[1].addBonusProtest(0, 2, "Bonus answer", "That should've been right", player.teamName);
+
+            appState.game.cycles[1].timeouts = [
+                {
+                    teamName: defaultTeamNames[0],
+                },
+            ];
+
+            appState.game.cycles[2].addPlayerLeaves(player);
+
+            const newPlayer: Player = new Player("Avery", defaultTeamNames[0], false);
+            appState.game.cycles[2].addPlayerJoins(newPlayer);
+
+            appState.game.cycles[3].addSwapSubstitution(player, newPlayer);
+
+            RenameTeamDialogController.changeNewName(name);
+            RenameTeamDialogController.renameTeam();
+
+            // Verify - dialog hidden, player is in game, add player event in cycle
+            expect(appState.uiState.dialogState.renameTeamDialog).to.be.undefined;
+
+            expect(appState.game.teamNames[0]).to.equal(name);
+            expect(appState.game.teamNames[1]).to.equal(defaultTeamNames[1]);
+
+            const wrongBuzzes: ITossupAnswerEvent[] | undefined = appState.game.cycles[0].wrongBuzzes;
+            if (wrongBuzzes === undefined) {
+                assert.fail("Expected wrongBuzzes event in the first cycle");
+            }
+
+            expect(wrongBuzzes.length).to.equal(1);
+            expect(wrongBuzzes[0].marker.player.name).to.equal(player.name);
+            expect(wrongBuzzes[0].marker.player.teamName).to.equal(name);
+
+            const tossupProtests: ITossupProtestEvent[] | undefined = appState.game.cycles[0].tossupProtests;
+            if (tossupProtests === undefined) {
+                assert.fail("Expected tossupProtests event in the first cycle");
+            }
+
+            expect(tossupProtests.length).to.equal(1);
+            expect(tossupProtests[0].teamName).to.equal(name);
+
+            const correctBuzz: ITossupAnswerEvent | undefined = appState.game.cycles[1].correctBuzz;
+            if (correctBuzz === undefined) {
+                assert.fail("Expected correctBuzz event in the second cycle");
+            }
+
+            expect(correctBuzz.marker.player.name).to.equal(player.name);
+            expect(correctBuzz.marker.player.teamName).to.equal(name);
+
+            const bonusProtests: IBonusProtestEvent[] | undefined = appState.game.cycles[1].bonusProtests;
+            if (bonusProtests === undefined) {
+                assert.fail("Expected bonusProtests event in the second cycle");
+            }
+
+            expect(bonusProtests.length).to.equal(1);
+            expect(bonusProtests[0].teamName).to.equal(name);
+
+            const thirdCycle = appState.game.cycles[2];
+            const playerLeaves: IPlayerLeavesEvent[] | undefined = thirdCycle.playerLeaves;
+            if (playerLeaves === undefined) {
+                assert.fail("Expected playerLeaves event in the third cycle");
+            }
+
+            expect(playerLeaves.length).to.equal(1);
+            expect(playerLeaves[0].outPlayer.name).to.equal(player.name);
+            expect(playerLeaves[0].outPlayer.teamName).to.equal(name);
+
+            const playerJoins: IPlayerJoinsEvent[] | undefined = thirdCycle.playerJoins;
+            if (playerJoins === undefined) {
+                assert.fail("Expected playerLeaves event in the third cycle");
+            }
+
+            expect(playerJoins.length).to.equal(1);
+            expect(playerJoins[0].inPlayer.name).to.equal(newPlayer.name);
+            expect(playerJoins[0].inPlayer.teamName).to.equal(name);
+
+            const subs: ISubstitutionEvent[] | undefined = appState.game.cycles[3].subs;
+            if (subs === undefined) {
+                assert.fail("Expected substitution event in the fourth cycle");
+            }
+
+            expect(subs.length).to.equal(1);
+
+            const sub: ISubstitutionEvent = subs[0];
+            expect(sub.inPlayer.name).to.equal(player.name);
+            expect(sub.inPlayer.teamName).to.equal(name);
+            expect(sub.outPlayer.name).to.equal(newPlayer.name);
+            expect(sub.outPlayer.teamName).to.equal(name);
+        });
+        it("renameTeam fails (empty name)", () => {
+            const appState: AppState = initializeApp();
+            RenameTeamDialogController.changeNewName(" ");
+            RenameTeamDialogController.renameTeam();
+
+            const state: RenameTeamDialogState = getRenameTeamDialogState(appState);
+            expect(state.errorMessage).to.not.be.undefined;
+            expect(appState.game.teamNames[0]).to.equal(defaultTeamNames[0]);
+            expect(appState.game.teamNames[1]).to.equal(defaultTeamNames[1]);
+        });
+        it("renameTeam fails (other team name)", () => {
+            const appState: AppState = initializeApp();
+            RenameTeamDialogController.changeNewName(defaultTeamNames[1]);
+            RenameTeamDialogController.renameTeam();
+
+            const state: RenameTeamDialogState = getRenameTeamDialogState(appState);
+            expect(state.errorMessage).to.not.be.undefined;
+            expect(appState.game.teamNames[0]).to.equal(defaultTeamNames[0]);
+            expect(appState.game.teamNames[1]).to.equal(defaultTeamNames[1]);
+        });
+        it("renameTeam succeeds (same team name)", () => {
+            const appState: AppState = initializeApp();
+            RenameTeamDialogController.changeNewName(defaultTeamNames[0]);
+            RenameTeamDialogController.renameTeam();
+
+            expect(appState.uiState.dialogState.renameTeamDialog).to.be.undefined;
+
+            const oldTeamNameIndex: number = appState.game.teamNames.indexOf(defaultTeamNames[0]);
+            expect(oldTeamNameIndex).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
- Let readers rename teams (#263)
    - Rename "Player Management" menu section to "Team Management"
- Add black as a pronunciation guide color (#267)
- Use text-decoration-skip-ink: none to make required parts more clear (#269)
- Code refactoring around dialogs
- Bump version to 1.26.0