### PR TITLE
Merged PR 309: v1.30.0 - Minor improvements (swap teams, new pronunci…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@fluentui/react";
 
 import * as BonusQuestionController from "./BonusQuestionController";
+import * as ReorderTeamsDialogController from "./dialogs/ReorderTeamsDialogController";
 import * as TossupQuestionController from "./TossupQuestionController";
 import { GameState } from "../state/GameState";
 import { UIState } from "../state/UIState";
@@ -95,6 +96,14 @@ export const GameBar = observer(function GameBar(): JSX.Element {
         uiState.dialogState.showReorderPlayersDialog(game.players);
     }, [uiState, game]);
 
+    const reorderTeamsHandler = React.useCallback(() => {
+        uiState.dialogState.showOKCancelMessageDialog(
+            "Reorder teams",
+            "Swap the order of teams?",
+            ReorderTeamsDialogController.submit
+        );
+    }, [uiState]);
+
     const renameTeamHandler = React.useCallback(() => {
         if (game.players.length === 0) {
             return;
@@ -155,6 +164,7 @@ export const GameBar = observer(function GameBar(): JSX.Element {
         addPlayerHandler,
         protestBonusHandler,
         reorderPlayersHandler,
+        reorderTeamsHandler,
         renameTeamHandler,
         addQuestionsHandler
     );
@@ -228,6 +238,7 @@ function getActionSubMenuItems(
     addPlayerHandler: () => void,
     protestBonusHandler: () => void,
     reorderPlayersHandler: () => void,
+    reorderTeamsHandler: () => void,
     renameTeamHandler: () => void,
     addQuestionsHandler: () => void
 ): ICommandBarItemProps[] {
@@ -241,6 +252,7 @@ function getActionSubMenuItems(
         uiState,
         addPlayerHandler,
         reorderPlayersHandler,
+        reorderTeamsHandler,
         renameTeamHandler
     );
     items.push(playerManagementSection);
@@ -439,6 +451,7 @@ function getPlayerManagementSubMenuItems(
     uiState: UIState,
     addPlayerHandler: () => void,
     reorderPlayersHandler: () => void,
+    reorderTeamsHandler: () => void,
     renameTeamHandler: () => void
 ): ICommandBarItemProps {
     const teamNames: string[] = game.teamNames;
@@ -551,28 +564,34 @@ function getPlayerManagementSubMenuItems(
     //       existing action (sub vs join)
     //     - Should there be a color code for active players?
 
+    const gameMenuItemsDisabled: boolean = appState.game.cycles.length === 0;
+
     const addPlayerItem: ICommandBarItemProps = {
         key: "addNewPlayer",
         text: "Add player...",
         onClick: addPlayerHandler,
-        // subMenuProps: {
-        //     items: addPlayerMenus,
-        // },
-        disabled: appState.game.cycles.length === 0,
+        disabled: gameMenuItemsDisabled,
     };
 
     const reorderPlayersItem: ICommandBarItemProps = {
         key: "reorderPlayers",
         text: "Reorder players...",
         onClick: reorderPlayersHandler,
-        disabled: appState.game.cycles.length === 0,
+        disabled: gameMenuItemsDisabled,
+    };
+
+    const reorderTeamsItem: ICommandBarItemProps = {
+        key: "reorderTeams",
+        text: "Reorder teams...",
+        onClick: reorderTeamsHandler,
+        disabled: gameMenuItemsDisabled,
     };
 
     const renameTeamItem: ICommandBarItemProps = {
         key: "renameTeam",
         text: "Rename team...",
         onClick: renameTeamHandler,
-        disabled: appState.game.cycles.length === 0,
+        disabled: gameMenuItemsDisabled,
     };
 
     return {
@@ -581,7 +600,7 @@ function getPlayerManagementSubMenuItems(
         sectionProps: {
             bottomDivider: true,
             title: "Team Management",
-            items: [playerActionsItem, addPlayerItem, reorderPlayersItem, renameTeamItem],
+            items: [playerActionsItem, addPlayerItem, reorderPlayersItem, reorderTeamsItem, renameTeamItem],
         },
     };
 }

--- a/src/components/QuestionViewer.tsx
+++ b/src/components/QuestionViewer.tsx
@@ -121,6 +121,7 @@ const getClassNames = memoizeFunction(
                 padding: "5px 10px",
                 fontSize,
                 color: fontColor,
+                lineHeight: "1.4",
             },
             separator: {
                 borderTop: "1px dotted black",

--- a/src/components/dialogs/ReorderTeamsDialogController.ts
+++ b/src/components/dialogs/ReorderTeamsDialogController.ts
@@ -1,0 +1,23 @@
+// For now this just uses a message dialog, but we want the logic someplace where we can test it
+
+import { Player } from "../../state/TeamState";
+import { AppState } from "../../state/AppState";
+
+export function submit(): void {
+    const appState: AppState = AppState.instance;
+    const players: Player[] = [...appState.game.players];
+    if (players.length < 2) {
+        return;
+    }
+
+    const firstPlayer: Player = players[0];
+    const otherPlayerIndex: number = players.findIndex((player) => player.teamName !== firstPlayer.teamName);
+    if (otherPlayerIndex === -1) {
+        return;
+    }
+
+    players[0] = players[otherPlayerIndex];
+    players[otherPlayerIndex] = firstPlayer;
+
+    appState.game.setPlayers(players);
+}

--- a/src/state/GameFormats.ts
+++ b/src/state/GameFormats.ts
@@ -2,7 +2,7 @@ import { IGameFormat, IPowerMarker } from "./IGameFormat";
 
 // We can't rely on a currentVersion we fill in, so these have to be manually tracked if there are breaking changes
 
-const currentVersion = "2021-07-11";
+const currentVersion = "2024-03-20";
 
 export const ACFGameFormat: IGameFormat = {
     bonusesBounceBack: false,
@@ -13,7 +13,7 @@ export const ACFGameFormat: IGameFormat = {
     powers: [],
     regulationTossupCount: 20,
     timeoutsAllowed: 1,
-    pronunciationGuideMarkers: ["(", ")"],
+    pronunciationGuideMarkers: ['("', '")'],
     pairTossupsBonuses: false,
     version: currentVersion,
 };
@@ -27,7 +27,7 @@ export const PACEGameFormat: IGameFormat = {
     powers: [{ marker: "(*)", points: 20 }],
     regulationTossupCount: 20,
     timeoutsAllowed: 1,
-    pronunciationGuideMarkers: ["(", ")"],
+    pronunciationGuideMarkers: ['("', '")'],
     pairTossupsBonuses: false,
     version: currentVersion,
 };
@@ -46,7 +46,7 @@ export const UndefinedGameFormat: IGameFormat = {
     powers: [{ marker: "(*)", points: 15 }],
     regulationTossupCount: 999,
     timeoutsAllowed: 999,
-    pronunciationGuideMarkers: ["(", ")"],
+    pronunciationGuideMarkers: ['("', '")'],
     pairTossupsBonuses: false,
     version: currentVersion,
 };

--- a/tests/FormattedTextParserTests.ts
+++ b/tests/FormattedTextParserTests.ts
@@ -118,7 +118,7 @@ describe("FormattedTextParserTests", () => {
             ]);
         });
         it("Pronunciation guide", () => {
-            const textToFormat = "This text is mine (mein).";
+            const textToFormat = 'This text is mine ("mein").';
             const result: IFormattedText[] = FormattedTextParser.parseFormattedText(textToFormat, {
                 pronunciationGuideMarkers: GameFormats.ACFGameFormat.pronunciationGuideMarkers,
             });
@@ -133,7 +133,7 @@ describe("FormattedTextParserTests", () => {
                     pronunciation: false,
                 },
                 {
-                    text: "(mein)",
+                    text: '("mein")',
                     bolded: false,
                     emphasized: false,
                     underlined: false,
@@ -153,7 +153,7 @@ describe("FormattedTextParserTests", () => {
             ]);
         });
         it("Bolded pronunciation guide", () => {
-            const textToFormat = "<b>Solano Lopez (LOW-pez)</b> was in this war.";
+            const textToFormat = '<b>Solano Lopez ("LOW-pez")</b> was in this war.';
             const result: IFormattedText[] = FormattedTextParser.parseFormattedText(textToFormat, {
                 pronunciationGuideMarkers: GameFormats.ACFGameFormat.pronunciationGuideMarkers,
             });
@@ -168,7 +168,7 @@ describe("FormattedTextParserTests", () => {
                     pronunciation: false,
                 },
                 {
-                    text: "(LOW-pez)",
+                    text: '("LOW-pez")',
                     bolded: true,
                     emphasized: false,
                     underlined: false,
@@ -223,13 +223,13 @@ describe("FormattedTextParserTests", () => {
             ]);
         });
         it("Different pronunciation guide", () => {
-            const textToFormat = "This text is mine (mein).";
+            const textToFormat = 'This text is mine ("mein").';
             const result: IFormattedText[] = FormattedTextParser.parseFormattedText(textToFormat, {
                 pronunciationGuideMarkers: ["[", "]"],
             });
             expect(result).to.deep.equal([
                 {
-                    text: "This text is mine (mein).",
+                    text: 'This text is mine ("mein").',
                     bolded: false,
                     emphasized: false,
                     underlined: false,
@@ -775,7 +775,7 @@ describe("FormattedTextParserTests", () => {
             expect(result).to.deep.equal(expected);
         });
         it("Pronunciation", () => {
-            const textToFormat = "There is a pronunciation guide (GUY-de) in this question.";
+            const textToFormat = 'There is a pronunciation guide ("GUY-de") in this question.';
             const result: IFormattedText[][] = FormattedTextParser.splitFormattedTextIntoWords(textToFormat, {
                 pronunciationGuideMarkers: GameFormats.ACFGameFormat.pronunciationGuideMarkers,
             });

--- a/tests/PacketStateTests.ts
+++ b/tests/PacketStateTests.ts
@@ -46,13 +46,13 @@ describe("PacketStateTests", () => {
             expect(formattedWord.pronunciation).to.be.false;
         });
         it("formattedQuestionText has pronunciation guide", () => {
-            const tossup: Tossup = new Tossup("My question (QWEST-shun) is this.", "Answer");
+            const tossup: Tossup = new Tossup('My question ("QWEST-shun") is this.', "Answer");
             const formattedText: IFormattedText[][] = tossup.getWords(noPowersGameFormat).map((word) => word.word);
             expect(formattedText.length).to.be.greaterThan(1);
             expect(formattedText[2].length).to.equal(1);
 
             const formattedWord: IFormattedText = formattedText[2][0];
-            expect(formattedWord.text).to.equal("(QWEST-shun)");
+            expect(formattedWord.text).to.equal('("QWEST-shun")');
             expect(formattedWord.bolded).to.be.false;
             expect(formattedWord.emphasized).to.be.false;
             expect(formattedWord.underlined).to.be.false;
@@ -71,8 +71,9 @@ describe("PacketStateTests", () => {
             expect(formattedWord.pronunciation).to.be.false;
         });
         it("formattedQuestionText has power marker with punctuation after it", () => {
+            const format: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
             const tossup: Tossup = new Tossup("The power marker (*), I think.", "Answer");
-            const formattedText: IFormattedText[][] = tossup.getWords(powersGameFormat).map((word) => word.word);
+            const formattedText: IFormattedText[][] = tossup.getWords(format).map((word) => word.word);
             expect(formattedText.length).to.be.greaterThan(1);
             expect(formattedText[3].length).to.equal(2);
             const formattedFirstPart: IFormattedText = formattedText[3][0];
@@ -114,7 +115,7 @@ describe("PacketStateTests", () => {
 
         it("With pronunciation guide", () => {
             const formattedText: IFormattedText[] = PacketState.getBonusWords(
-                "<b>This is</b> my bonus (BONE-us) part",
+                '<b>This is</b> my bonus ("BONE-us") part',
                 GameFormats.ACFGameFormat
             );
 
@@ -128,7 +129,7 @@ describe("PacketStateTests", () => {
             expect(formattedText[1].pronunciation).to.be.false;
             expect(formattedText[1].bolded).to.be.false;
 
-            expect(formattedText[2].text).to.equal("(BONE-us)");
+            expect(formattedText[2].text).to.equal('("BONE-us")');
             expect(formattedText[2].pronunciation).to.be.true;
             expect(formattedText[2].bolded).to.be.false;
 
@@ -139,7 +140,7 @@ describe("PacketStateTests", () => {
 
         it("With multiple pronunciation guide", () => {
             const formattedText: IFormattedText[] = PacketState.getBonusWords(
-                "<u>Another</u> (an-OTH-er) bonus (BONE-us) part",
+                '<u>Another</u> ("an-OTH-er") bonus ("BONE-us") part',
                 GameFormats.ACFGameFormat
             );
 
@@ -154,13 +155,13 @@ describe("PacketStateTests", () => {
             expect(formattedText[1].underlined).to.be.false;
 
             expect(formattedText.slice(2).map((text) => text.underlined)).to.not.contain(true);
-            expect(formattedText[2].text).to.equal("(an-OTH-er)");
+            expect(formattedText[2].text).to.equal('("an-OTH-er")');
             expect(formattedText[2].pronunciation).to.be.true;
 
             expect(formattedText[3].text).to.equal(" bonus ");
             expect(formattedText[3].pronunciation).to.be.false;
 
-            expect(formattedText[4].text).to.equal("(BONE-us)");
+            expect(formattedText[4].text).to.equal('("BONE-us")');
             expect(formattedText[4].pronunciation).to.be.true;
 
             expect(formattedText[5].text).to.equal(" part");
@@ -234,31 +235,31 @@ describe("PacketStateTests", () => {
         });
         it("In power with pronunciation guide", () => {
             const gameFormat: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
-            const tossup: Tossup = new Tossup("This question (quest-shun) is my (*) question", "Answer");
+            const tossup: Tossup = new Tossup('This question ("quest-shun") is my (*) question', "Answer");
             const points: number = tossup.getPointsAtPosition(gameFormat, 3);
             expect(points).to.equal(15);
         });
         it("In power with multiple pronunciation guides", () => {
             const gameFormat: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
-            const tossup: Tossup = new Tossup("This question (quest-shun) is my (mai) (*) question", "Answer");
+            const tossup: Tossup = new Tossup('This question ("quest-shun") is my ("mai") (*) question', "Answer");
             const points: number = tossup.getPointsAtPosition(gameFormat, 3);
             expect(points).to.equal(15);
         });
         it("In power with pronunciation guide followed by a period", () => {
             const gameFormat: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
-            const tossup: Tossup = new Tossup("This is a question (quest-shun). It is my (*) question", "Answer");
+            const tossup: Tossup = new Tossup('This is a question ("quest-shun"). It is my (*) question', "Answer");
             const points: number = tossup.getPointsAtPosition(gameFormat, 4);
             expect(points).to.equal(15);
         });
         it("Out of power with pronunciation guide", () => {
             const gameFormat: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
-            const tossup: Tossup = new Tossup("This question (quest-shun) is my (*) question", "Answer");
+            const tossup: Tossup = new Tossup('This question ("quest-shun") is my (*) question', "Answer");
             const points: number = tossup.getPointsAtPosition(gameFormat, 4);
             expect(points).to.equal(10);
         });
         it("Out of power with multiple pronunciation guides", () => {
             const gameFormat: IGameFormat = { ...powersGameFormat, pronunciationGuideMarkers: ["(", ")"] };
-            const tossup: Tossup = new Tossup("This question (quest-shun) is my (mai) (*) question", "Answer");
+            const tossup: Tossup = new Tossup('This question ("quest-shun") is my (mai) (*) question', "Answer");
             const points: number = tossup.getPointsAtPosition(gameFormat, 4);
             expect(points).to.equal(10);
         });
@@ -299,12 +300,12 @@ describe("PacketStateTests", () => {
             expect(points).to.equal(0);
         });
         it("Wrong before the last word (pronunciation guide)", () => {
-            const tossup: Tossup = new Tossup("This is my question (qwest-shun)", "Answer");
+            const tossup: Tossup = new Tossup('This is my question ("qwest-shun")', "Answer");
             const points: number = tossup.getPointsAtPosition(noPowersGameFormat, 3, false);
             expect(points).to.equal(-5);
         });
         it("Wrong at the last word (pronunciation guide)", () => {
-            const tossup: Tossup = new Tossup("This is my question (qwest-shun)", "Answer");
+            const tossup: Tossup = new Tossup('This is my question ("qwest-shun")', "Answer");
             const points: number = tossup.getPointsAtPosition(noPowersGameFormat, 4, false);
             expect(points).to.equal(0);
         });

--- a/tests/ReorderTeamsDialogControllerTests.ts
+++ b/tests/ReorderTeamsDialogControllerTests.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+
+import * as ReorderTeamsDialogController from "src/components/dialogs/ReorderTeamsDialogController";
+import { AppState } from "src/state/AppState";
+import { GameState } from "src/state/GameState";
+import { PacketState, Tossup } from "src/state/PacketState";
+import { Player } from "src/state/TeamState";
+
+const defaultPacket: PacketState = new PacketState();
+defaultPacket.setTossups([
+    new Tossup("first q", "first a"),
+    new Tossup("second q", "second a"),
+    new Tossup("third q", "third a"),
+]);
+
+const defaultTeamNames: string[] = ["First Team", "Team2"];
+
+const firstTeamPlayers: Player[] = [
+    new Player("Alex", defaultTeamNames[0], true),
+    new Player("Anna", defaultTeamNames[0], true),
+    new Player("Ashok", defaultTeamNames[0], false),
+];
+
+const secondTeamPlayers: Player[] = [new Player("Bob", defaultTeamNames[1], true)];
+
+const defaultExistingPlayers: Player[] = [
+    firstTeamPlayers[0],
+    firstTeamPlayers[1],
+    firstTeamPlayers[2],
+    secondTeamPlayers[0],
+];
+
+function initializeApp(players?: Player[]): { appState: AppState; players: Player[] } {
+    const gameState: GameState = new GameState();
+    gameState.loadPacket(defaultPacket);
+
+    players = players ?? defaultExistingPlayers;
+    gameState.addNewPlayers(players);
+
+    AppState.resetInstance();
+    const appState: AppState = AppState.instance;
+    appState.game = gameState;
+    return { appState, players };
+}
+
+describe("ReorderTeamsDialogControllerTests", () => {
+    it("submit with less than 2 doesn't break", () => {
+        const { appState } = initializeApp([firstTeamPlayers[0]]);
+
+        ReorderTeamsDialogController.submit();
+        expect(appState.game.teamNames).to.be.deep.equal([defaultTeamNames[0]]);
+    });
+    it("submit with lonly 1 team doesn't break", () => {
+        const { appState } = initializeApp([firstTeamPlayers[0], firstTeamPlayers[1]]);
+
+        ReorderTeamsDialogController.submit();
+        expect(appState.game.teamNames).to.be.deep.equal([defaultTeamNames[0]]);
+    });
+    it("submit with 2", () => {
+        const { appState } = initializeApp([firstTeamPlayers[0], secondTeamPlayers[0]]);
+
+        ReorderTeamsDialogController.submit();
+        expect(appState.game.teamNames).to.be.deep.equal([defaultTeamNames[1], defaultTeamNames[0]]);
+    });
+    it("submit with several", () => {
+        const { appState } = initializeApp();
+
+        ReorderTeamsDialogController.submit();
+        expect(appState.game.teamNames).to.be.deep.equal([defaultTeamNames[1], defaultTeamNames[0]]);
+    });
+});


### PR DESCRIPTION
…ation guide default, line height change)

- Move default pronunciation guide to be `("` and `")`, which prevents issues where words with parentheses in them (like some chemicals) are incorrectly marked as pronunciation guides (#250)
- Add a menu item for swapping the order of teams (#274)
- Change the line height for question text to 1.4 to improve readability (#270)
- Bump version to 1.30.0