### PR TITLE
v1.34.0 - Show the packet name at the bottom when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.33.3",
+    "version": "1.34.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -387,6 +387,13 @@ function getViewSubMenuItems(appState: AppState): ICommandBarItemProps[] {
             onClick: () => appState.uiState.toggleEventLogVisibility(),
         },
         {
+            key: "showPacketName",
+            text: "Packet Name",
+            canCheck: true,
+            checked: !appState.uiState.isPacketNameHidden,
+            onClick: () => appState.uiState.togglePacketNameVisibility(),
+        },
+        {
             key: "showBonusAlways",
             text: "Always show bonus",
             canCheck: true,

--- a/src/components/GameViewer.tsx
+++ b/src/components/GameViewer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { IStackTokens, Label, mergeStyleSets, Stack, StackItem, Text } from "@fluentui/react";
+import { IStackTokens, mergeStyleSets, Stack, StackItem } from "@fluentui/react";
 
 import { QuestionViewerContainer } from "./QuestionViewerContainer";
 import { Scoreboard } from "./Scoreboard";

--- a/src/components/GameViewer.tsx
+++ b/src/components/GameViewer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
-import { IStackTokens, mergeStyleSets, Stack, StackItem } from "@fluentui/react";
+import { IStackTokens, Label, mergeStyleSets, Stack, StackItem, Text } from "@fluentui/react";
 
 import { QuestionViewerContainer } from "./QuestionViewerContainer";
 import { Scoreboard } from "./Scoreboard";
@@ -10,6 +10,7 @@ import { AppState } from "../state/AppState";
 import { StateContext } from "../contexts/StateContext";
 import { Clock } from "./Clock";
 import { ExportStatus } from "./ExportStatus";
+import { PacketNameLabel } from "./PacketNameLabel";
 
 const scoreboardAndQuestionViewerTokens: IStackTokens = { childrenGap: 20 };
 
@@ -25,7 +26,9 @@ export const GameViewer = observer(function GameViewer() {
 
     // Include an empty div to keep the scoreboard centered
     const showClock: boolean = gameExists && !appState.uiState.isClockHidden;
+    const showPacketName: boolean = gameExists && !appState.uiState.isPacketNameHidden;
     const clock = showClock ? <Clock className={classes.clock} /> : undefined;
+    const packetName = showPacketName ? <PacketNameLabel /> : undefined;
     const clockSpaceFiller = showClock ? <div></div> : undefined;
 
     // TODO: See if we should convert the game viewer section into a StackItem. It's using a grid now, so it might
@@ -49,6 +52,7 @@ export const GameViewer = observer(function GameViewer() {
                         <StackItem>
                             <QuestionViewerContainer />
                         </StackItem>
+                        <StackItem>{packetName}</StackItem>
                         <StackItem>
                             <ExportStatus />
                         </StackItem>

--- a/src/components/ModaqControl.tsx
+++ b/src/components/ModaqControl.tsx
@@ -189,6 +189,11 @@ export interface IModaqControlProps {
     packet?: IPacket;
 
     /**
+     * The name of the packet.
+     */
+    packetName?: string;
+
+    /**
      * The players in the current game. This should only be set once.
      */
     players?: IPlayer[];
@@ -335,6 +340,14 @@ function update(appState: AppState, props: IModaqControlProps): void {
 
     if (props.hideNewGame !== appState.uiState.hideNewGame) {
         appState.uiState.setHideNewGame(props.hideNewGame == true);
+    }
+
+    if (props.packetName !== appState.uiState.packetFilename) {
+        if (props.packetName != undefined) {
+            appState.uiState.setPacketFilename(props.packetName);
+        } else {
+            appState.uiState.resetPacketFilename();
+        }
     }
 }
 

--- a/src/components/PacketNameLabel.tsx
+++ b/src/components/PacketNameLabel.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Text } from "@fluentui/react";
+import { observer } from "mobx-react-lite";
+
+import { AppState } from "../state/AppState";
+import { StateContext } from "../contexts/StateContext";
+
+export const PacketNameLabel = observer(function PacketNameLabel() {
+    const appState: AppState = React.useContext(StateContext);
+
+    if (!appState.uiState.packetFilename) {
+        return <></>;
+    }
+
+    return <Text>Packet: {appState.uiState.packetFilename}</Text>;
+});

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -101,6 +101,9 @@ export class UIState {
     // Default should be to show the export status. This setting didn't exist before, so use hide instead of show
     public isCustomExportStatusHidden: boolean;
 
+    // Default should be to show the packet name. This setting didn't exist before, so use hide instead of show
+    public isPacketNameHidden: boolean;
+
     // Default should be to have it horizontal.
     public isScoreVertical: boolean;
 
@@ -143,6 +146,7 @@ export class UIState {
 
         this.isClockHidden = false;
         this.isEventLogHidden = false;
+        this.isPacketNameHidden = false;
         this.isCustomExportStatusHidden = false;
         this.isScoreVertical = false;
         this.importGameStatus = undefined;
@@ -591,6 +595,10 @@ export class UIState {
 
     public toggleHideBonusOnDeadTossup(): void {
         this.hideBonusOnDeadTossup = !this.hideBonusOnDeadTossup;
+    }
+
+    public togglePacketNameVisibility(): void {
+        this.isPacketNameHidden = !this.isPacketNameHidden;
     }
 
     public toggleScoreVerticality(): void {


### PR DESCRIPTION
- Show the packet name at the bottom when available. This lets readers know what set they have loaded (#43)
    - Add packetName field to IModaqControlProps to control this in the embedded case
- vite security fix
- Bump version to 1.34.0