### PR TITLE
v1.35.1 - Make New game window wider by default, and remove wi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.35.0",
+    "version": "1.35.1",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/ModaqControl.tsx
+++ b/src/components/ModaqControl.tsx
@@ -228,7 +228,7 @@ function initializeControl(appState: AppState, props: IModaqControlProps): () =>
             // Need to check if game is old and prompt the user if they want to restart the game.
             // Date subtraction gives you the number of milliseconds
             const lastUpdate: number | undefined = appState.game.lastUpdate?.getTime();
-            if (lastUpdate != undefined && Date.now() - lastUpdate > minAgeToPromptForReset) {
+            if (lastUpdate && Date.now() - lastUpdate > minAgeToPromptForReset) {
                 appState.uiState.dialogState.showOKCancelMessageDialog(
                     "Start new game?",
                     "The loaded game is over 5 days old. Do you want to start a new game instead?",

--- a/src/components/PlayerRoster.tsx
+++ b/src/components/PlayerRoster.tsx
@@ -164,6 +164,7 @@ export const PlayerRoster = observer(function PlayerRoster(props: IPlayerRosterP
             items={props.players}
             onRenderItemColumn={renderPlayerRow}
             selectionMode={SelectionMode.single}
+            compact={true}
         ></DetailsList>
     );
 });

--- a/src/components/dialogs/NewGameDialog.tsx
+++ b/src/components/dialogs/NewGameDialog.tsx
@@ -47,7 +47,7 @@ import { FilePicker } from "../FilePicker";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
 import { IResult } from "../../IResult";
 
-const playerListHeight = "20vh";
+const playerListHeight = "25vh";
 
 const enum PivotKey {
     Manual = "M",
@@ -82,7 +82,9 @@ const modalProps: IModalProps = {
             // To have max width respected normally, we'd need to pass in an IDialogStyleProps, but it ridiculously
             // requires you to pass in an entire theme to modify the max width. We could also use a modal, but that
             // requires building much of what Dialogs offer easily (close buttons, footer for buttons)
-            maxWidth: "80% !important",
+            minWidth: "60% !important",
+            maxWidth: "90% !important",
+            maxHeight: "95% !important",
             top: "5vh",
         },
     },
@@ -707,7 +709,6 @@ const getClassNames = (): INewGameDialogBodyClassNames =>
             gridTemplateColumns: "5fr 1fr 5fr",
             marginBottom: 20,
             minHeight: "25vh",
-            width: "50vw",
         },
         teamNameInput: {
             marginBottom: "10px",


### PR DESCRIPTION
…dth for team entries to...

- Make New game window wider by default and remove width for team entries to prevent clipping move up/down buttons.
- Reduce the spacing between players in the From Registration view (helps with #296)
- Fix bug where "old game" dialog appears on refresh when the last game had no events
- Bump version to 1.35.1