### PR TITLE
Merged PR 350: v1.39.0 - Protest improvements

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,31 +4,30 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    push:
+        branches: ["master"]
+    pull_request:
+        branches: ["master"]
 
 jobs:
-  build:
+    build:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                # We don't really use Node
+                node-version: [22.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    strategy:
-      matrix:
-        # We don't really use Node
-        node-version: [18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm run init
-    - run: npm run build --if-present
-    - run: npm run buildDemo
-    - run: npm run lint
-    - run: npm test
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm run init
+            - run: npm run build --if-present
+            - run: npm run buildDemo
+            - run: npm run lint
+            - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ node_modules
 
 npm-debug.log
 
+# output directories for build and buildDemo, respectively
 out
 dist
+
+# code coverage reports
+coverage/*

--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ To use MODAQ in your project as an npm package:
 
 1. Add `modaq` as a dependency to your `package.json` file:
 
-   ```bash
-   npm install modaq
-   ```
+    ```bash
+    npm install modaq
+    ```
 
 2. In your React file, import MODAQ with:
 
-   ```typescript
-   import * as Modaq from "modaq";
-   ```
+    ```typescript
+    import * as Modaq from "modaq";
+    ```
 
-   Then use the control like `<Modaq.ModaqControl />`.
+    Then use the control like `<Modaq.ModaqControl />`.
 
 3. If you want to export to Google Sheets format, you need to supply your application's client ID and include this in your HTML:
 
-   ```html
-   <script async defer src="https://apis.google.com/js/api.js"></script>
-   ```
+    ```html
+    <script async defer src="https://apis.google.com/js/api.js"></script>
+    ```
 
 4. If you want to use the packet parser (instead of passing in a packet parameter), you need to include a URL to YAPP.
 
@@ -40,9 +40,9 @@ See [the MODAQ Wiki](https://github.com/alopezlago/MODAQ/wiki/Codebase-Overview)
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (version 14 or higher)
-- [yarn](https://yarnpkg.com/getting-started/install)
-- [npm](https://www.npmjs.com/get-npm)
+-   [Node.js](https://nodejs.org/) (version 14 or higher)
+-   [yarn](https://yarnpkg.com/getting-started/install)
+-   [npm](https://www.npmjs.com/get-npm)
 
 VS Code is recommended as an IDE. If using VS Code, install the Prettier extension for code formatting.
 
@@ -50,18 +50,18 @@ VS Code is recommended as an IDE. If using VS Code, install the Prettier extensi
 
 1. Download the [latest release](https://github.com/alopezlago/MODAQ/releases) or clone the repository:
 
-   ```bash
-   git clone https://github.com/alopezlago/MODAQ.git
-   cd MODAQ
-   ```
+    ```bash
+    git clone https://github.com/alopezlago/MODAQ.git
+    cd MODAQ
+    ```
 
 2. Install dependencies:
 
-   ```bash
-   npm install
-   # or
-   yarn install
-   ```
+    ```bash
+    npm install
+    # or
+    yarn install
+    ```
 
 ### Building
 
@@ -89,23 +89,23 @@ For testing via the Dev server (required for Google Sheets functionality), which
 
 1. Add this entry to your hosts file (on macOS/Linux: `/etc/hosts`, on Windows: `C:\Windows\System32\drivers\etc\hosts`):
 
-   ```bash
-   127.0.0.1 localhost.quizbowlreader.com
-   ```
+    ```bash
+    127.0.0.1 localhost.quizbowlreader.com
+    ```
 
-   - If using Chrome, you may also need to set the flag at `chrome://flags#local-network-access-check`.
+    - If using Chrome, you may also need to set the flag at `chrome://flags#local-network-access-check`.
 
 2. Run the dev server:
 
-   ```bash
-   npm run dev
-   # or
-   yarn dev
-   ```
+    ```bash
+    npm run dev
+    # or
+    yarn dev
+    ```
 
 3. Open https://localhost.quizbowlreader.com:5173/out
 
-   You can accept the HTTPS certificate or create your own self-signed certificate.
+    You can accept the HTTPS certificate or create your own self-signed certificate.
 
 ### Testing
 
@@ -160,10 +160,14 @@ yarn serve
 Contributions are welcome! Please follow these steps:
 
 1. [Fork the repository.](https://github.com/alopezlago/MODAQ/fork) and create a feature branch.
-   - Alternatively, you can clone this repository, and create a feature branch on this repository directly.
+    - Alternatively, you can clone this repository, and create a feature branch on this repository directly.
 2. Commit your changes to the feature branch.
 3. Ensure `npm run lint` and `npm test` pass without warnings or failures.
 4. Submit a [pull request](https://github.com/alopezlago/MODAQ/compare).
+
+### AI policy
+
+Because it's unclear whether LLM-generated code can be copyrighted, LLM-generated code should be limited to tests or refactoring of existing code.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.38.1",
+    "version": "1.39.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",
@@ -31,6 +31,7 @@
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "@typescript-eslint/parser": "^5.31.0",
         "@vitejs/plugin-react": "^4.3.2",
+        "c8": "^11.0.0",
         "chai": "^4.3.0",
         "copyfiles": "^2.4.1",
         "eslint": "^8.20.0",
@@ -70,6 +71,7 @@
         "test": "mocha --recursive tests/**/*.ts --exit --check-leaks -r tests/TestInit.js -r ts-node/register -r tsconfig-paths/register",
         "dev": "vite",
         "buildDemo": "tsc && vite build --mode production",
-        "serve": "vite preview"
+        "serve": "vite preview",
+        "codeCoverage": "c8 --reporter=lcov --reporter=text-summary npm run test"
     }
 }

--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -78,7 +78,9 @@ function getPlayerMenuItems(props: IBuzzMenuProps, theme: Theme | undefined, tea
                     PlayerUtils.playersEqual(buzz.marker.player, player) && buzz.marker.position === props.wordIndex
             ) >= 0;
         const isProtestChecked: boolean =
-            props.cycle.tossupProtests?.findIndex((protest) => protest.position === props.wordIndex) != undefined;
+            (isCorrectChecked || isWrongChecked) &&
+            props.cycle.tossupProtests != undefined &&
+            props.cycle.tossupProtests.findIndex((protest) => protest.teamName === player.teamName) >= 0;
 
         const buzzMenuItemData: IBuzzMenuItemData = { props, player };
 
@@ -246,7 +248,7 @@ function onProtestClicked(
     const { props, player } = { ...item.data };
 
     if (item.checked) {
-        props.cycle.removeTossupProtest(player.teamName);
+        props.appState.uiState.dialogState.showRemoveTossupProtestDialog(props.cycle, player.teamName);
     } else if (item.checked === false) {
         props.appState.uiState.setPendingTossupProtest(player.teamName, props.tossupNumber - 1, props.wordIndex);
     }

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -17,7 +17,7 @@ import { Cycle } from "../state/Cycle";
 import { Bonus, Tossup } from "../state/PacketState";
 import { Player } from "../state/TeamState";
 import { AppState } from "../state/AppState";
-import { ITossupAnswerEvent } from "../state/Events";
+import { IBonusProtestEvent, ITossupAnswerEvent, ITossupProtestEvent } from "../state/Events";
 import { useAppState } from "../contexts/StateContext";
 import { StatusDisplayType } from "../state/StatusDisplayType";
 
@@ -695,6 +695,42 @@ function getProtestSubMenuItems(
         }
     }
 
+    const copyProtestInfoSubItems: ICommandBarItemProps[] = [];
+    if (cycle?.tossupProtests != undefined) {
+        for (const protest of cycle.tossupProtests) {
+            copyProtestInfoSubItems.push({
+                key: `copyTossupProtest_${protest.teamName}`,
+                text: `${protest.teamName}'s buzz`,
+                onClick: () => {
+                    const protestInfo: string = buildCopyTossupProtestInfoText(appState, cycle, protest);
+                    copyProtestInfo(uiState, protestInfo);
+                },
+            });
+        }
+    }
+
+    if (cycle?.bonusProtests != undefined) {
+        for (const protest of cycle.bonusProtests) {
+            copyProtestInfoSubItems.push({
+                key: `copyBonusProtest_${protest.teamName}_${protest.partIndex}`,
+                text: `Bonus part ${protest.partIndex + 1}`,
+                onClick: () => {
+                    const protestInfo: string = buildCopyBonusProtestInfoText(appState, cycle, protest);
+                    copyProtestInfo(uiState, protestInfo);
+                },
+            });
+        }
+    }
+
+    const copyProtestInfoItem: ICommandBarItemProps = {
+        key: "copyProtestInfo",
+        text: "Copy protest info",
+        subMenuProps: {
+            items: copyProtestInfoSubItems,
+        },
+        disabled: copyProtestInfoSubItems.length === 0,
+    };
+
     if (protestTossupItems == undefined) {
         protestTossupItems = {
             key: "protestTossup",
@@ -717,7 +753,7 @@ function getProtestSubMenuItems(
         sectionProps: {
             bottomDivider: true,
             title: "Protests",
-            items: [protestTossupItems, protestBonusItem],
+            items: [protestTossupItems, protestBonusItem, copyProtestInfoItem],
         },
     };
 }
@@ -757,7 +793,7 @@ function onProtestTossupClick(
 
     // If this item is checked, then clear the protest
     if (item.checked === true) {
-        cycle.removeTossupProtest(teamName);
+        uiState.dialogState.showRemoveTossupProtestDialog(cycle, teamName);
         return;
     }
 
@@ -769,6 +805,75 @@ function onProtestTossupClick(
     }
 
     uiState.setPendingTossupProtest(teamName, tossupIndex, item.data.buzz.marker.position);
+}
+
+function buildCopyTossupProtestInfoText(appState: AppState, cycle: Cycle, protest: ITossupProtestEvent): string {
+    const game: GameState = appState.game;
+    const uiState: UIState = appState.uiState;
+    const packetName: string = uiState.packetFilename != undefined ? `"${uiState.packetFilename}"` : "";
+
+    const tossup: Tossup = game.packet.tossups[protest.questionIndex];
+    return `* Packet ${packetName}
+* Cycle #${uiState.cycleIndex + 1}
+* Tossup #${protest.questionIndex + 1}
+* Packet Answerline: ${tossup.answer}
+* Player Answer: ${protest.givenAnswer}
+* Buzzpoint: Word #${protest.position} (${tossup
+        .getWords(game.gameFormat)
+        .filter((w) => w.canBuzzOn)
+        [protest.position].word.map((w) => w.text)
+        .join(" ")})
+* Metadata: ${tossup.metadata}
+* Moderator Judgment: ${
+        cycle.correctBuzz == undefined || cycle.correctBuzz.marker.player.teamName !== protest.teamName
+            ? "Incorrect"
+            : "Correct"
+    }
+* Justification: ${protest.reason}
+* Protest Matters: ${game.protestsMatter ? "Yes" : "No"}`;
+}
+
+function buildCopyBonusProtestInfoText(appState: AppState, cycle: Cycle, protest: IBonusProtestEvent): string {
+    const game: GameState = appState.game;
+    const uiState: UIState = appState.uiState;
+    const packetName: string = uiState.packetFilename != undefined ? `"${uiState.packetFilename}"` : "";
+    const bonus: Bonus = game.packet.bonuses[protest.questionIndex];
+
+    return `* Packet ${packetName}
+* Cycle #${uiState.cycleIndex + 1}
+* Bonus #${protest.questionIndex + 1}, Part #${protest.partIndex + 1}
+* Packet Answerline: ${bonus.parts[protest.partIndex].answer}
+* Player Answer: ${protest.givenAnswer}
+* Metadata: ${bonus.metadata}
+* Moderator Judgment: ${
+        cycle.bonusAnswer === undefined || cycle.bonusAnswer.parts[protest.partIndex].points <= 0
+            ? "Incorrect"
+            : "Correct"
+    }
+* Justification: ${protest.reason}
+* Protest Matters: ${game.protestsMatter ? "Yes" : "No"}`;
+}
+
+function copyProtestInfo(uiState: UIState, protestInfo: string): void {
+    try {
+        navigator.clipboard
+            .writeText(protestInfo)
+            .then(() => onCopyProtestInfoSuccess(uiState))
+            .catch(() => onCopyProtestInfoFailure(uiState));
+    } catch {
+        onCopyProtestInfoFailure(uiState);
+    }
+}
+
+function onCopyProtestInfoSuccess(uiState: UIState): void {
+    uiState.dialogState.showOKMessageDialog("Copied", "Protest info has been copied to clipboard.");
+}
+
+function onCopyProtestInfoFailure(uiState: UIState): void {
+    uiState.dialogState.showOKMessageDialog(
+        "Error",
+        "Unable to copy protest info to clipboard. Please allow MODAQ access to the clipboard."
+    );
 }
 
 function onPlayerLeaveClick(

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -12,6 +12,7 @@ import { ModalVisibilityStatus } from "./ModalVisibilityStatus";
 import { RenameTeamDialogState } from "./RenameTeamDialogState";
 import { ImportFromQBJDialogState } from "./ImportFromQBJDialogState";
 import { AddPlayerDialogState } from "./AddPlayerDialogState";
+import { Cycle } from "./Cycle";
 
 export class DialogState {
     @ignore
@@ -171,6 +172,12 @@ export class DialogState {
     public showImportFromQBJDialog(): void {
         this.importFromQBJDialog = new ImportFromQBJDialogState();
         this.visibleDialog = ModalVisibilityStatus.ImportFromQBJ;
+    }
+
+    public showRemoveTossupProtestDialog(cycle: Cycle, teamName: string): void {
+        this.showOKCancelMessageDialog("Remove protest", `Remove tossup protest for "${teamName}"?`, () => {
+            cycle.removeTossupProtest(teamName);
+        });
     }
 
     public showRenamePlayerDialog(player: Player): void {

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -210,7 +210,9 @@ export class GameState {
                     const tossup: Tossup | undefined = this.packet.tossups[tossupProtest.questionIndex];
 
                     if (tossup != undefined) {
+                        let rewardOtherTeamPoints = true;
                         let tossupTeamIndex: number = tossupProtest.teamName === this.teamNames[0] ? 0 : 1;
+
                         if (cycle.correctBuzz) {
                             // If the correct buzz is for the protesting team, then this should be for "against"
                             if (
@@ -219,6 +221,14 @@ export class GameState {
                             ) {
                                 tossupTeamIndex = 1 - tossupTeamIndex;
                             }
+
+                            // The other team negged before the team they're protesting, so they couldn't score any
+                            // additional points even if the protest went through.
+                            rewardOtherTeamPoints =
+                                cycle.wrongBuzzes == undefined ||
+                                !cycle.wrongBuzzes.some(
+                                    (buzz) => buzz.marker.player.teamName !== tossupProtest.teamName
+                                );
 
                             // We have a correct buzz... we need to discount this buzz for the other team, plus any
                             // bonus they got
@@ -241,18 +251,28 @@ export class GameState {
                             swings[1 - tossupTeamIndex].against += correctTossupPoints + bonusPoints;
                         }
 
-                        const bonusIndex: number = this.getBonusIndex(i);
-                        const potentialBonusPoints =
-                            this.packet.bonuses[bonusIndex]?.parts.reduce(
-                                (previous, current) => current.value + previous,
-                                0
-                            ) ?? 0;
-
                         // Need to remove the neg (subtract) and add what the correct value would be
-                        swings[tossupTeamIndex].for +=
-                            tossup.getPointsAtPosition(this.gameFormat, tossupProtest.position, /* isCorrect */ true) -
-                            tossup.getPointsAtPosition(this.gameFormat, tossupProtest.position, /* isCorrect */ false) +
-                            potentialBonusPoints;
+                        if (rewardOtherTeamPoints) {
+                            const bonusIndex: number = this.getBonusIndex(i);
+                            const potentialBonusPoints =
+                                this.packet.bonuses[bonusIndex]?.parts.reduce(
+                                    (previous, current) => current.value + previous,
+                                    0
+                                ) ?? 0;
+
+                            swings[tossupTeamIndex].for +=
+                                tossup.getPointsAtPosition(
+                                    this.gameFormat,
+                                    tossupProtest.position,
+                                    /* isCorrect */ true
+                                ) -
+                                tossup.getPointsAtPosition(
+                                    this.gameFormat,
+                                    tossupProtest.position,
+                                    /* isCorrect */ false
+                                ) +
+                                potentialBonusPoints;
+                        }
                     }
                 }
             }

--- a/tests/ProtestsMatterTests.ts
+++ b/tests/ProtestsMatterTests.ts
@@ -161,6 +161,275 @@ describe("GameStateTests", () => {
             game.cycles[3].addTossupProtest(secondTeamPlayer.teamName, 2, 1, "My answer", "My reason");
             expect(game.protestsMatter).to.be.true;
         });
+        it("Uneven game, tossup protest can remove a neg and add tossup plus bonus", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+
+            game.cycles[1].addWrongBuzz(
+                { player: secondTeamPlayer, points: -5, position: 1, isLastWord: false },
+                1,
+                game.gameFormat
+            );
+            game.cycles[1].addTossupProtest(secondTeamPlayer.teamName, 1, 1, "My answer", "My reason");
+
+            expect(game.protestsMatter).to.be.true;
+        });
+        it("Uneven game, tossup protest against other team's correct answer only removes their points", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+            game.cycles[0].addTossupProtest(secondTeamPlayer.teamName, 0, 2, "My answer", "My reason");
+
+            game.cycles[1].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 1, isLastWord: false },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+
+            expect(game.protestsMatter).to.be.true;
+        });
+        it("Uneven game, protest against an accepted correct buzz can use that team's name", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+
+            // This matches the current UI flow for protesting the accepted correct buzz itself.
+            game.cycles[0].addTossupProtest(firstTeamPlayer.teamName, 0, 2, "My answer", "My reason");
+
+            game.cycles[1].addCorrectBuzz(
+                { player: secondTeamPlayer, points: 10, position: 1, isLastWord: false },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+
+            expect(game.protestsMatter).to.be.true;
+        });
+        it("Uneven game, protest against an accepted correct buzz using that team's name does not matter after a neg", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addWrongBuzz(
+                { player: secondTeamPlayer, points: -5, position: 1, isLastWord: false },
+                0,
+                game.gameFormat
+            );
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+
+            // This also matches the current UI flow for protesting the accepted correct buzz itself.
+            game.cycles[0].addTossupProtest(firstTeamPlayer.teamName, 0, 2, "My answer", "My reason");
+
+            game.cycles[1].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 1, isLastWord: false },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+
+            expect(game.protestsMatter).to.be.false;
+        });
+        it("Uneven game, invalid tossup protest question index is ignored", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].addTossupProtest(secondTeamPlayer.teamName, 99, 2, "My answer", "My reason");
+
+            expect(game.protestsMatter).to.be.false;
+        });
+        it("Uneven game, end-of-question protest can matter by removing the other team's score", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addWrongBuzz(
+                { player: secondTeamPlayer, points: 0, position: 2, isLastWord: true },
+                0,
+                game.gameFormat
+            );
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: true },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+            game.cycles[0].addTossupProtest(secondTeamPlayer.teamName, 0, 2, "My answer", "My reason");
+
+            game.cycles[1].addWrongBuzz(
+                { player: firstTeamPlayer, points: -5, position: 1, isLastWord: false },
+                1,
+                game.gameFormat
+            );
+            game.cycles[1].addWrongBuzz(
+                { player: secondTeamPlayer, points: 0, position: 2, isLastWord: true },
+                1,
+                game.gameFormat
+            );
+
+            expect(game.protestsMatter).to.be.true;
+        });
+        it("Uneven game, end-of-question protest does not matter if the other team still leads", () => {
+            const game: GameState = createDefaultGame();
+
+            game.cycles[0].addWrongBuzz(
+                { player: secondTeamPlayer, points: 0, position: 2, isLastWord: true },
+                0,
+                game.gameFormat
+            );
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: true },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+            game.cycles[0].addTossupProtest(secondTeamPlayer.teamName, 0, 2, "My answer", "My reason");
+
+            game.cycles[1].addWrongBuzz(
+                { player: secondTeamPlayer, points: -5, position: 1, isLastWord: false },
+                1,
+                game.gameFormat
+            );
+
+            expect(game.protestsMatter).to.be.true;
+
+            game.cycles[1].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: true },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+
+            expect(game.protestsMatter).to.be.true;
+
+            game.cycles[1].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+
+            expect(game.protestsMatter).to.be.false;
+        });
+        it("Uneven game, multiple bonus protests can matter together", () => {
+            const packet: PacketState = new PacketState();
+            packet.setTossups([new Tossup("first q", "first a"), new Tossup("second q", "second a")]);
+            packet.setBonuses([
+                new Bonus("first leadin", [
+                    { question: "first bonus 1", answer: "first answer 1", value: 10 },
+                    { question: "first bonus 2", answer: "first answer 2", value: 10 },
+                ]),
+                new Bonus("second leadin", [{ question: "second bonus 1", answer: "second answer 1", value: 10 }]),
+            ]);
+
+            const game: GameState = new GameState();
+            game.addNewPlayers(players);
+            game.loadPacket(packet);
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 2, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                2
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+            game.cycles[0].setBonusPartAnswer(1, firstTeamPlayer.teamName, 10);
+            game.cycles[0].addBonusProtest(0, 0, "My answer", "My reason", secondTeamPlayer.teamName);
+            game.cycles[0].addBonusProtest(0, 1, "My answer 2", "My reason 2", secondTeamPlayer.teamName);
+
+            game.cycles[1].addCorrectBuzz(
+                { player: secondTeamPlayer, points: 10, position: 1, isLastWord: false },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+
+            expect(game.protestsMatter).to.be.true;
+        });
+        it("Uneven game, tossup protest uses the protested question's bonus value after a thrown out bonus", () => {
+            const packet: PacketState = new PacketState();
+            packet.setTossups([
+                new Tossup("first q", "first a"),
+                new Tossup("second q", "second a"),
+                new Tossup("third q", "third a"),
+            ]);
+            packet.setBonuses([
+                new Bonus("first leadin", [{ question: "first bonus", answer: "first answer", value: 10 }]),
+                new Bonus("second leadin", [{ question: "second bonus", answer: "second answer", value: 10 }]),
+                new Bonus("third leadin", [{ question: "third bonus", answer: "third answer", value: 10 }]),
+            ]);
+
+            const game: GameState = new GameState();
+            game.addNewPlayers(players);
+            game.loadPacket(packet);
+
+            game.cycles[0].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 1, isLastWord: false },
+                0,
+                game.gameFormat,
+                0,
+                1
+            );
+            game.cycles[0].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+            game.cycles[0].addTossupProtest(firstTeamPlayer.teamName, 0, 1, "My answer", "My reason");
+            game.cycles[0].addThrownOutBonus(0);
+
+            game.cycles[1].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 1, isLastWord: false },
+                1,
+                game.gameFormat,
+                1,
+                1
+            );
+            game.cycles[1].setBonusPartAnswer(0, firstTeamPlayer.teamName, 10);
+
+            expect(game.protestsMatter).to.be.true;
+
+            game.cycles[2].addCorrectBuzz(
+                { player: firstTeamPlayer, points: 10, position: 1, isLastWord: false },
+                2,
+                game.gameFormat,
+                1,
+                1
+            );
+            expect(game.protestsMatter).to.be.false;
+        });
         it("Uneven game, bonus protest matters (for)", () => {
             const game: GameState = createDefaultGame();
             game.cycles[0].addCorrectBuzz(

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,6 +181,11 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
+"@bcoe/v8-coverage@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
+
 "@emnapi/core@^1.4.3":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
@@ -511,6 +516,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -539,6 +549,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.12":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
@@ -924,6 +942,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@types/he/-/he-1.1.2.tgz#0c8b275f36d2b8b651104638e4d45693349c3953"
   integrity sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==
+
+"@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
 
 "@types/json-schema@^7.0.9":
   version "7.0.11"
@@ -1370,6 +1393,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 before-after-hook@^2.2.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
@@ -1394,6 +1422,13 @@ brace-expansion@^2.0.1:
   integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -1421,6 +1456,23 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+c8@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-11.0.0.tgz#d0420d93b90202490041c338a8aa95174eca0586"
+  integrity sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.1"
+    "@istanbuljs/schema" "^0.1.3"
+    find-up "^5.0.0"
+    foreground-child "^3.1.1"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.1.6"
+    test-exclude "^8.0.0"
+    v8-to-istanbul "^9.0.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1537,6 +1589,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
@@ -1601,7 +1662,7 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -2289,9 +2350,9 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -2326,6 +2387,14 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+foreground-child@^3.1.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
 
 form-data@^4.0.5:
   version "4.0.5"
@@ -2498,6 +2567,15 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
+  dependencies:
+    minimatch "^10.2.2"
+    minipass "^7.1.3"
+    path-scurry "^2.0.2"
+
 glob@^7.0.5:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -2647,6 +2725,11 @@ he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -3064,6 +3147,28 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.1.6:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -3146,6 +3251,11 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^11.0.0:
+  version "11.3.6"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.3.6.tgz#f0306ad6e9f0a5dc25b16aeba4e8f57b7ec2df55"
+  integrity sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -3159,6 +3269,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -3202,6 +3319,13 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^10.2.2:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
 minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -3218,6 +3342,11 @@ minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+minipass@^7.1.2, minipass@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -3521,6 +3650,14 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -3868,6 +4005,11 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.3:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
+  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
+
 semver@^7.7.1:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
@@ -3972,6 +4114,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
@@ -4016,6 +4163,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string.prototype.matchall@^4.0.7:
   version "4.0.7"
@@ -4179,6 +4335,15 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+test-exclude@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-8.0.0.tgz#85891add3fa46bb822b1b1579c7f8c9a3d04ebd8"
+  integrity sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^13.0.6"
+    minimatch "^10.2.2"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -4431,6 +4596,15 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
+v8-to-istanbul@^9.0.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
+
 vite-plugin-mkcert@^1.17.6:
   version "1.17.6"
   resolved "https://registry.yarnpkg.com/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.6.tgz#c514d3d72ba201997e29cc537538bf8ff126c5c2"
@@ -4580,6 +4754,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs-unparser@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
@@ -4602,6 +4781,19 @@ yargs@16.2.0, yargs@^16.1.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Add a menu item for copying protest information (#372)
- Fix an issue where you can't have multiple tossup protests on the same question (#381)
- Fix a bug where the protest swing didn't take the opponent's incorrect buzz into account, leading to cases where a protest was incorrectly marked as mattering
- Prompt the user before removing a tossup protest through the buzz menu or game bar (#382)
- Bump version to 1.39.0