### PR TITLE
v1.40.0 - various protest improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "modaq",
-    "version": "1.39.0",
+    "version": "1.40.0",
     "description": "Quiz Bowl Reader using TypeScript, React, and MobX",
     "repository": {
         "type": "git",

--- a/src/components/BonusQuestionController.ts
+++ b/src/components/BonusQuestionController.ts
@@ -2,11 +2,11 @@ import { AppState } from "../state/AppState";
 import { Cycle } from "../state/Cycle";
 
 export function throwOutBonus(appState: AppState, cycle: Cycle, bonusIndex: number): void {
-    appState.uiState.dialogState.showOKCancelMessageDialog(
-        "Throw out Bonus",
-        "Click OK to throw out the bonus. To undo this, click on the X next to its event in the Event Log.",
-        () => onConfirmThrowOutBonus(cycle, bonusIndex)
-    );
+    appState.uiState.dialogState.showOKCancelMessageDialog({
+        title: "Throw out Bonus",
+        message: "Click OK to throw out the bonus. To undo this, click on the X next to its event in the Event Log.",
+        onOK: () => onConfirmThrowOutBonus(cycle, bonusIndex),
+    });
 }
 
 function onConfirmThrowOutBonus(cycle: Cycle, bonusIndex: number) {

--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -150,6 +150,9 @@ function onBuzzMenuDismissed(props: IBuzzMenuProps): void {
 
     if (props.appState.uiState.buzzMenuState.clearSelectedWordOnClose) {
         props.appState.uiState.setSelectedWordIndex(-1);
+    } else {
+        const selectedWord = (props.target as React.MutableRefObject<HTMLElement | null>)?.current;
+        selectedWord?.focus();
     }
 }
 
@@ -248,7 +251,7 @@ function onProtestClicked(
     const { props, player } = { ...item.data };
 
     if (item.checked) {
-        props.appState.uiState.dialogState.showRemoveTossupProtestDialog(props.cycle, player.teamName);
+        props.appState.uiState.showRemoveTossupProtestDialog(props.cycle, player.teamName);
     } else if (item.checked === false) {
         props.appState.uiState.setPendingTossupProtest(player.teamName, props.tossupNumber - 1, props.wordIndex);
     }

--- a/src/components/CancelButton.tsx
+++ b/src/components/CancelButton.tsx
@@ -17,7 +17,11 @@ export const CancelButton = observer(function CancelButton(props: ICancelButtonP
             return;
         }
 
-        appState.uiState.dialogState.showOKCancelMessageDialog(props.prompt.title, props.prompt.message, props.onClick);
+        appState.uiState.dialogState.showOKCancelMessageDialog({
+            title: props.prompt.title,
+            message: props.prompt.message,
+            onOK: props.onClick,
+        });
     };
 
     return (

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -667,11 +667,12 @@ function getProtestSubMenuItems(appState: AppState, game: GameState, uiState: UI
             if (bonus && bonus.parts.length > 0) {
                 const bonusProtestSubMenuItems: ICommandBarItemProps[] = [];
                 for (let i = 0; i < bonus.parts.length; i++) {
+                    // This is potentially quadratic, but bonus parts should be few in number
                     const bonusProtestExists = !protestableParts.includes(i);
 
                     const protestBonusPartHandler = () => {
+                        // Somehow a bonus disappeared or the bonus answer did when handled. It should never happen
                         if (bonus == undefined || cycle.bonusAnswer == undefined) {
-                            // Something is wrong... the bonus is undefined, but this handler can be accessed?
                             throw new Error(
                                 `Impossible to add bonus protest for bonus question ${bonusIndex}, part ${i + 1}`
                             );

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -32,10 +32,11 @@ export const GameBar = observer(function GameBar(): JSX.Element {
     const newGameHandler = React.useCallback(() => {
         if (appState.game.hasUpdates) {
             // Prompt the user
-            uiState.dialogState.showYesNoCancelMessageDialog(
-                "Export Game?",
-                "The game has changes that haven't been exported. Would you like to export the game before starting a new one?",
-                () => {
+            uiState.dialogState.showYesNoCancelMessageDialog({
+                title: "Export Game?",
+                message:
+                    "The game has changes that haven't been exported. Would you like to export the game before starting a new one?",
+                onYes: () => {
                     // Open the export dialog, depending on if they have sheets. We should ideally abstract this logic
                     // to another method
                     if (appState.uiState.customExportOptions != undefined) {
@@ -47,13 +48,13 @@ export const GameBar = observer(function GameBar(): JSX.Element {
                         appState.uiState.dialogState.showExportToJsonDialog();
                     }
                 },
-                () => {
+                onNo: () => {
                     // User doesn't want any updates, so clear them
                     appState.game.markUpdateComplete();
                     uiState.createPendingNewGame();
                     uiState.dialogState.showNewGameDialog();
-                }
-            );
+                },
+            });
         } else {
             uiState.createPendingNewGame();
             uiState.dialogState.showNewGameDialog();
@@ -66,24 +67,6 @@ export const GameBar = observer(function GameBar(): JSX.Element {
     const importFromQBJHandler = React.useCallback(() => {
         uiState.dialogState.showImportFromQBJDialog();
     }, [uiState]);
-
-    const protestBonusHandler = React.useCallback(() => {
-        // Issue: pending protest needs existing index. Need to update it to include the part number
-        const cycle: Cycle = game.cycles[uiState.cycleIndex];
-        if (cycle?.bonusAnswer == undefined) {
-            return;
-        }
-
-        const bonusIndex: number = game.getBonusIndex(uiState.cycleIndex);
-        const bonus: Bonus | undefined = game.packet.bonuses[bonusIndex];
-        if (bonus == undefined) {
-            // Something is wrong... the bonus is undefined, but this handler can be accessed?
-            throw new Error(`Impossible to add bonus protest for bonus question ${bonusIndex}`);
-        }
-
-        const protestableParts: number[] = cycle.getProtestableBonusPartIndexes(bonus.parts.length);
-        uiState.setPendingBonusProtest(cycle.bonusAnswer.receivingTeamName, bonusIndex, protestableParts[0]);
-    }, [game, uiState]);
 
     const addPlayerHandler = React.useCallback(() => {
         uiState.dialogState.showAddPlayerDialog(game.teamNames[0]);
@@ -100,9 +83,11 @@ export const GameBar = observer(function GameBar(): JSX.Element {
     }, [uiState, game]);
 
     const reorderTeamsHandler = React.useCallback(() => {
-        uiState.dialogState.showOKCancelMessageDialog("Reorder teams", "Swap the order of teams?", () =>
-            ReorderTeamsDialogController.submit(appState)
-        );
+        uiState.dialogState.showOKCancelMessageDialog({
+            title: "Reorder teams",
+            message: "Swap the order of teams?",
+            onOK: () => ReorderTeamsDialogController.submit(appState),
+        });
     }, [appState, uiState]);
 
     const renameTeamHandler = React.useCallback(() => {
@@ -169,7 +154,6 @@ export const GameBar = observer(function GameBar(): JSX.Element {
     const actionSubMenuItems: ICommandBarItemProps[] = getActionSubMenuItems(
         appState,
         addPlayerHandler,
-        protestBonusHandler,
         reorderPlayersHandler,
         reorderTeamsHandler,
         renameTeamHandler,
@@ -243,7 +227,6 @@ async function exportToSheets(appState: AppState): Promise<void> {
 function getActionSubMenuItems(
     appState: AppState,
     addPlayerHandler: () => void,
-    protestBonusHandler: () => void,
     reorderPlayersHandler: () => void,
     reorderTeamsHandler: () => void,
     renameTeamHandler: () => void,
@@ -264,7 +247,7 @@ function getActionSubMenuItems(
     );
     items.push(playerManagementSection);
 
-    const protestsSection: ICommandBarItemProps = getProtestSubMenuItems(appState, game, uiState, protestBonusHandler);
+    const protestsSection: ICommandBarItemProps = getProtestSubMenuItems(appState, game, uiState);
     items.push(protestsSection);
 
     const removeQuestionSection: ICommandBarItemProps = {
@@ -621,12 +604,7 @@ function getPlayerManagementSubMenuItems(
     };
 }
 
-function getProtestSubMenuItems(
-    appState: AppState,
-    game: GameState,
-    uiState: UIState,
-    protestBonusHandler: () => void
-): ICommandBarItemProps {
+function getProtestSubMenuItems(appState: AppState, game: GameState, uiState: UIState): ICommandBarItemProps {
     const cycle: Cycle | undefined =
         uiState.cycleIndex < game.cycles.length ? game.cycles[uiState.cycleIndex] : undefined;
 
@@ -636,7 +614,7 @@ function getProtestSubMenuItems(
     if (cycle?.orderedBuzzes != undefined) {
         const tossupIndex: number = game.getTossupIndex(uiState.cycleIndex);
         if (tossupIndex !== -1) {
-            const protestSubMenuItems: ICommandBarItemProps[] = [];
+            const tossupProtestSubMenuItems: ICommandBarItemProps[] = [];
             for (const buzz of cycle.orderedBuzzes) {
                 const { name, teamName } = buzz.marker.player;
                 const tossupProtestItemData: ITossupProtestMenuItemData = {
@@ -644,7 +622,7 @@ function getProtestSubMenuItems(
                     buzz,
                 };
 
-                const protestExists: boolean =
+                const tossupProtestExists: boolean =
                     cycle.tossupProtests != undefined &&
                     cycle.tossupProtests.findIndex((protest) => protest.teamName === teamName) >= 0;
 
@@ -652,12 +630,12 @@ function getProtestSubMenuItems(
                     key: `protest${teamName}_${name}`,
                     text: `${name} (${teamName})`,
                     canCheck: true,
-                    checked: protestExists,
+                    checked: tossupProtestExists,
                     data: tossupProtestItemData,
                     onClick: onProtestTossupClick,
                 };
 
-                const protestSection: ICommandBarItemProps = {
+                const tossupProtestSection: ICommandBarItemProps = {
                     key: `protestSection${teamName}_${name}`,
                     itemType: ContextualMenuItemType.Section,
                     sectionProps: {
@@ -667,16 +645,16 @@ function getProtestSubMenuItems(
                     },
                 };
 
-                protestSubMenuItems.push(protestSection);
+                tossupProtestSubMenuItems.push(tossupProtestSection);
             }
 
             protestTossupItems = {
                 key: "protestTossup",
                 text: "Protest tossup...",
                 subMenuProps: {
-                    items: protestSubMenuItems,
+                    items: tossupProtestSubMenuItems,
                 },
-                disabled: protestSubMenuItems.length === 0,
+                disabled: tossupProtestSubMenuItems.length === 0,
             };
         }
     }
@@ -685,11 +663,59 @@ function getProtestSubMenuItems(
         const bonusIndex: number = game.getBonusIndex(uiState.cycleIndex);
         if (bonusIndex !== -1) {
             const bonus: Bonus = game.packet.bonuses[bonusIndex];
-            if (cycle.getProtestableBonusPartIndexes(bonus.parts.length).length > 0) {
+            const protestableParts: number[] = cycle.getProtestableBonusPartIndexes(bonus.parts.length);
+            if (bonus && bonus.parts.length > 0) {
+                const bonusProtestSubMenuItems: ICommandBarItemProps[] = [];
+                for (let i = 0; i < bonus.parts.length; i++) {
+                    const bonusProtestExists = !protestableParts.includes(i);
+
+                    const protestBonusPartHandler = () => {
+                        if (bonus == undefined || cycle.bonusAnswer == undefined) {
+                            // Something is wrong... the bonus is undefined, but this handler can be accessed?
+                            throw new Error(
+                                `Impossible to add bonus protest for bonus question ${bonusIndex}, part ${i + 1}`
+                            );
+                        }
+
+                        if (bonusProtestExists) {
+                            appState.uiState.showRemoveBonusProtestDialog(cycle, i);
+                            return;
+                        }
+
+                        uiState.setPendingBonusProtest(cycle.bonusAnswer.receivingTeamName, bonusIndex, i);
+                    };
+
+                    const bonusProtestItem: ICommandBarItemProps = {
+                        key: `protestBonusPart_${i}`,
+                        text: `${i + 1}`,
+                        canCheck: true,
+                        checked: bonusProtestExists,
+                        data: {
+                            appState,
+                            bonus: bonus,
+                            partIndex: i,
+                        },
+                        onClick: protestBonusPartHandler,
+                    };
+                    bonusProtestSubMenuItems.push(bonusProtestItem);
+                }
+
+                const bonusProtestSection: ICommandBarItemProps = {
+                    key: "bonusProtestSection",
+                    itemType: ContextualMenuItemType.Section,
+                    sectionProps: {
+                        bottomDivider: true,
+                        title: "Parts",
+                        items: bonusProtestSubMenuItems,
+                    },
+                };
+
                 protestBonusItem = {
                     key: "protestBonus",
                     text: "Protest bonus...",
-                    onClick: protestBonusHandler,
+                    subMenuProps: {
+                        items: [bonusProtestSection],
+                    },
                 };
             }
         }
@@ -793,7 +819,7 @@ function onProtestTossupClick(
 
     // If this item is checked, then clear the protest
     if (item.checked === true) {
-        uiState.dialogState.showRemoveTossupProtestDialog(cycle, teamName);
+        uiState.showRemoveTossupProtestDialog(cycle, teamName);
         return;
     }
 
@@ -814,23 +840,22 @@ function buildCopyTossupProtestInfoText(appState: AppState, cycle: Cycle, protes
 
     const tossup: Tossup = game.packet.tossups[protest.questionIndex];
     return `* Packet ${packetName}
-* Cycle #${uiState.cycleIndex + 1}
-* Tossup #${protest.questionIndex + 1}
-* Packet Answerline: ${tossup.answer}
-* Player Answer: ${protest.givenAnswer}
-* Buzzpoint: Word #${protest.position} (${tossup
+* **Cycle**: #${uiState.cycleIndex + 1}
+* **Tossup**: #${protest.questionIndex + 1}
+* **Metadata**: ${tossup.metadata}
+* **Packet Answerline**: ${tossup.answer}
+* **Player Answer**: ${protest.givenAnswer}
+* **Buzzpoint**: Word #${protest.position} (${tossup
         .getWords(game.gameFormat)
         .filter((w) => w.canBuzzOn)
         [protest.position].word.map((w) => w.text)
         .join(" ")})
-* Metadata: ${tossup.metadata}
-* Moderator Judgment: ${
+* **Moderator Judgment**: ${
         cycle.correctBuzz == undefined || cycle.correctBuzz.marker.player.teamName !== protest.teamName
             ? "Incorrect"
             : "Correct"
     }
-* Justification: ${protest.reason}
-* Protest Matters: ${game.protestsMatter ? "Yes" : "No"}`;
+* **Justification**: ${protest.reason}`;
 }
 
 function buildCopyBonusProtestInfoText(appState: AppState, cycle: Cycle, protest: IBonusProtestEvent): string {
@@ -840,18 +865,17 @@ function buildCopyBonusProtestInfoText(appState: AppState, cycle: Cycle, protest
     const bonus: Bonus = game.packet.bonuses[protest.questionIndex];
 
     return `* Packet ${packetName}
-* Cycle #${uiState.cycleIndex + 1}
-* Bonus #${protest.questionIndex + 1}, Part #${protest.partIndex + 1}
-* Packet Answerline: ${bonus.parts[protest.partIndex].answer}
-* Player Answer: ${protest.givenAnswer}
-* Metadata: ${bonus.metadata}
-* Moderator Judgment: ${
+* **Cycle**: #${uiState.cycleIndex + 1}
+* **Bonus**: #${protest.questionIndex + 1}, Part #${protest.partIndex + 1}
+* **Metadata**: ${bonus.metadata}
+* **Packet Answerline**: ${bonus.parts[protest.partIndex].answer}
+* **Player Answer**: ${protest.givenAnswer}
+* **Moderator Judgment**: ${
         cycle.bonusAnswer === undefined || cycle.bonusAnswer.parts[protest.partIndex].points <= 0
             ? "Incorrect"
             : "Correct"
     }
-* Justification: ${protest.reason}
-* Protest Matters: ${game.protestsMatter ? "Yes" : "No"}`;
+* **Justification**: ${protest.reason}`;
 }
 
 function copyProtestInfo(uiState: UIState, protestInfo: string): void {
@@ -866,14 +890,17 @@ function copyProtestInfo(uiState: UIState, protestInfo: string): void {
 }
 
 function onCopyProtestInfoSuccess(uiState: UIState): void {
-    uiState.dialogState.showOKMessageDialog("Copied", "Protest info has been copied to clipboard.");
+    uiState.dialogState.showOKMessageDialog({
+        title: "Copied",
+        message: "Protest info has been copied to clipboard.",
+    });
 }
 
 function onCopyProtestInfoFailure(uiState: UIState): void {
-    uiState.dialogState.showOKMessageDialog(
-        "Error",
-        "Unable to copy protest info to clipboard. Please allow MODAQ access to the clipboard."
-    );
+    uiState.dialogState.showOKMessageDialog({
+        title: "Error",
+        message: "Unable to copy protest info to clipboard. Please allow MODAQ access to the clipboard.",
+    });
 }
 
 function onPlayerLeaveClick(
@@ -888,13 +915,13 @@ function onPlayerLeaveClick(
 
     const appState: AppState = item.data.appState;
 
-    appState.uiState.dialogState.showOKCancelMessageDialog(
-        "Let Player Leave",
-        `Are you sure you want to let the player "${item.data.activePlayer.name}" from team "${
+    appState.uiState.dialogState.showOKCancelMessageDialog({
+        title: "Let Player Leave",
+        message: `Are you sure you want to let the player "${item.data.activePlayer.name}" from team "${
             item.data.activePlayer.teamName
         }" leave the game before question #${appState.uiState.cycleIndex + 1}?`,
-        () => appState.game.cycles[appState.uiState.cycleIndex].addPlayerLeaves(item.data.activePlayer)
-    );
+        onOK: () => appState.game.cycles[appState.uiState.cycleIndex].addPlayerLeaves(item.data.activePlayer),
+    });
 }
 
 function onRenamePlayerClick(
@@ -936,13 +963,14 @@ function onSwapPlayerClick(
         Math.abs(cycleIndex - halftimeIndex) <= 1
             ? ` If you want to substitute a player at halftime, do it on question ${Math.floor(halftimeIndex + 1)}.`
             : "";
-    item.data.appState.uiState.dialogState.showOKCancelMessageDialog(
-        "Substitute Player",
-        `You are substituting players outside of a normal time (beginning of the game, after halftime, overtime). Are you sure you want to substitute before question #${
-            cycleIndex + 1
-        }?` + additionalHint,
-        () => game.cycles[uiState.cycleIndex].addSwapSubstitution(item.data.player, item.data.activePlayer)
-    );
+    item.data.appState.uiState.dialogState.showOKCancelMessageDialog({
+        title: "Substitute Player",
+        message:
+            `You are substituting players outside of a normal time (beginning of the game, after halftime, overtime). Are you sure you want to substitute before question #${
+                cycleIndex + 1
+            }?` + additionalHint,
+        onOK: () => game.cycles[uiState.cycleIndex].addSwapSubstitution(item.data.player, item.data.activePlayer),
+    });
 }
 
 function isSubMenuItemData(data: ISubMenuItemData | undefined): data is ISubMenuItemData {

--- a/src/components/ModaqControl.tsx
+++ b/src/components/ModaqControl.tsx
@@ -233,14 +233,14 @@ function initializeControl(appState: AppState, props: IModaqControlProps): () =>
             // Date subtraction gives you the number of milliseconds
             const lastUpdate: number | undefined = appState.game.lastUpdate?.getTime();
             if (lastUpdate && Date.now() - lastUpdate > minAgeToPromptForReset) {
-                appState.uiState.dialogState.showOKCancelMessageDialog(
-                    "Start new game?",
-                    "The loaded game is over 5 days old. Do you want to start a new game instead?",
-                    () => {
+                appState.uiState.dialogState.showOKCancelMessageDialog({
+                    title: "Start new game?",
+                    message: "The loaded game is over 5 days old. Do you want to start a new game instead?",
+                    onOK: () => {
                         appState.uiState.createPendingNewGame();
                         appState.uiState.dialogState.showNewGameDialog();
-                    }
-                );
+                    },
+                });
             }
         });
     }

--- a/src/components/TossupQuestionController.ts
+++ b/src/components/TossupQuestionController.ts
@@ -47,11 +47,11 @@ export function selectWordFromKeyboardEvent(appState: AppState, event: React.Key
 }
 
 export function throwOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number): void {
-    appState.uiState.dialogState.showOKCancelMessageDialog(
-        "Throw out Tossup",
-        "Click OK to throw out the tossup. To undo this, click on the X next to its event in the Event Log.",
-        () => onConfirmThrowOutTossup(appState, cycle, tossupNumber)
-    );
+    appState.uiState.dialogState.showOKCancelMessageDialog({
+        title: "Throw out Tossup",
+        message: "Click OK to throw out the tossup. To undo this, click on the X next to its event in the Event Log.",
+        onOK: () => onConfirmThrowOutTossup(appState, cycle, tossupNumber),
+    });
 }
 
 function onConfirmThrowOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number) {

--- a/src/components/dialogs/BonusProtestDialog.tsx
+++ b/src/components/dialogs/BonusProtestDialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react-lite";
-import { Dropdown, IDropdownOption } from "@fluentui/react/lib/Dropdown";
+import { Label } from "@fluentui/react";
 
 import * as BonusProtestDialogController from "./BonusProtestDialogController";
 import { ProtestDialogBase } from "./ProtestDialogBase";
@@ -16,30 +16,12 @@ export const BonusProtestDialog = observer(function BonusProtestDialog(props: IB
         props.cycle,
     ]);
     const hideDialogHandler = (): void => BonusProtestDialogController.cancel(props.appState);
-    const partChangeHandler = (ev: React.FormEvent<HTMLDivElement>, option?: IDropdownOption): void => {
-        if (option?.text != undefined) {
-            BonusProtestDialogController.changePart(props.appState, option.key);
-        }
-    };
 
     const protestEvent: IBonusProtestEvent | undefined = props.appState.uiState.pendingBonusProtestEvent;
     if (protestEvent == undefined) {
         // We shouldn't be showing anything if there's no pending bonus protest. Return undefined.
         return <></>;
     }
-
-    const partOptions: IDropdownOption[] = props.cycle
-        .getProtestableBonusPartIndexes(props.bonus.parts.length)
-        .map((index) => {
-            const partText: string = (index + 1).toString();
-            return {
-                key: index,
-                text: partText,
-                selected: protestEvent.partIndex === index,
-            };
-        });
-
-    const children: JSX.Element = <Dropdown label="Part" options={partOptions} onChange={partChangeHandler} />;
 
     return (
         <ProtestDialogBase
@@ -50,7 +32,7 @@ export const BonusProtestDialog = observer(function BonusProtestDialog(props: IB
             reason={protestEvent.reason}
             visibilityStatus={ModalVisibilityStatus.BonusProtest}
         >
-            {children}
+            <Label>Protest for part {protestEvent.partIndex + 1}</Label>
         </ProtestDialogBase>
     );
 });

--- a/src/components/dialogs/BonusProtestDialogController.ts
+++ b/src/components/dialogs/BonusProtestDialogController.ts
@@ -21,13 +21,26 @@ export function commit(appState: AppState, cycle: Cycle): void {
     }
 
     if (pendingProtestEvent) {
-        cycle.addBonusProtest(
-            pendingProtestEvent.questionIndex,
-            pendingProtestEvent.partIndex,
-            pendingProtestEvent.givenAnswer,
-            pendingProtestEvent.reason,
-            teamName
-        );
+        const existingProtest = cycle.bonusProtests?.find((protest) => {
+            return (
+                protest.questionIndex === pendingProtestEvent.questionIndex &&
+                protest.partIndex === pendingProtestEvent.partIndex
+            );
+        });
+
+        if (existingProtest) {
+            existingProtest.givenAnswer = pendingProtestEvent.givenAnswer;
+            existingProtest.reason = pendingProtestEvent.reason;
+        } else {
+            cycle.addBonusProtest(
+                pendingProtestEvent.questionIndex,
+                pendingProtestEvent.partIndex,
+                pendingProtestEvent.givenAnswer,
+                pendingProtestEvent.reason,
+                teamName
+            );
+        }
+
         appState.uiState.resetPendingBonusProtest();
     }
 }

--- a/src/components/dialogs/MessageDialog.tsx
+++ b/src/components/dialogs/MessageDialog.tsx
@@ -29,7 +29,7 @@ export const MessageDialog = observer(function MessageDialog(): JSX.Element {
     const noButton: JSX.Element | undefined =
         messageDialog.type === MessageDialogType.YesNocCancel ? (
             <DefaultButton
-                text="No"
+                text={messageDialog.noLabel ?? "No"}
                 onClick={() => {
                     if (messageDialog.onNo !== undefined) {
                         messageDialog.onNo();
@@ -45,7 +45,10 @@ export const MessageDialog = observer(function MessageDialog(): JSX.Element {
             <DefaultButton text="Cancel" onClick={closeHandler} />
         );
 
-    const okButtonText = messageDialog.type === MessageDialogType.YesNocCancel ? "Yes" : "OK";
+    const okButtonText =
+        messageDialog.type === MessageDialogType.YesNocCancel
+            ? messageDialog.yesLabel ?? "Yes"
+            : messageDialog.okLabel ?? "OK";
 
     return (
         <ModalDialog

--- a/src/components/dialogs/TossupProtestDialogController.ts
+++ b/src/components/dialogs/TossupProtestDialogController.ts
@@ -5,13 +5,26 @@ import { ITossupProtestEvent } from "../../state/Events";
 export function commit(appState: AppState, cycle: Cycle): void {
     const pendingProtestEvent: ITossupProtestEvent | undefined = appState.uiState.pendingTossupProtestEvent;
     if (pendingProtestEvent) {
-        cycle.addTossupProtest(
-            pendingProtestEvent.teamName,
-            pendingProtestEvent.questionIndex,
-            pendingProtestEvent.position,
-            pendingProtestEvent.givenAnswer,
-            pendingProtestEvent.reason
-        );
+        const existingProtest = cycle.tossupProtests?.find((protest) => {
+            return (
+                protest.teamName === pendingProtestEvent.teamName &&
+                protest.questionIndex === pendingProtestEvent.questionIndex
+            );
+        });
+
+        if (existingProtest) {
+            existingProtest.givenAnswer = pendingProtestEvent.givenAnswer;
+            existingProtest.reason = pendingProtestEvent.reason;
+        } else {
+            cycle.addTossupProtest(
+                pendingProtestEvent.teamName,
+                pendingProtestEvent.questionIndex,
+                pendingProtestEvent.position,
+                pendingProtestEvent.givenAnswer,
+                pendingProtestEvent.reason
+            );
+        }
+
         appState.uiState.resetPendingTossupProtest();
     }
 }

--- a/src/components/dialogs/TossupProtestDialogController.ts
+++ b/src/components/dialogs/TossupProtestDialogController.ts
@@ -7,8 +7,8 @@ export function commit(appState: AppState, cycle: Cycle): void {
     if (pendingProtestEvent) {
         const existingProtest = cycle.tossupProtests?.find((protest) => {
             return (
-                protest.teamName === pendingProtestEvent.teamName &&
-                protest.questionIndex === pendingProtestEvent.questionIndex
+                protest.questionIndex === pendingProtestEvent.questionIndex &&
+                protest.teamName === pendingProtestEvent.teamName
             );
         });
 

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -56,10 +56,10 @@ export class AppState {
                 if (status.isError) {
                     switch (displayType) {
                         case StatusDisplayType.MessageDialog:
-                            this.uiState.dialogState.showOKMessageDialog(
-                                "Export Error",
-                                `Export failed: ${status.status}.`
-                            );
+                            this.uiState.dialogState.showOKMessageDialog({
+                                title: "Export Error",
+                                message: `Export failed: ${status.status}.`,
+                            });
                             break;
                         case StatusDisplayType.Label:
                             this.uiState.setCustomExportStatus(`Export failed: ${status.status}.`);
@@ -71,7 +71,10 @@ export class AppState {
                     this.game.markUpdateComplete();
                     switch (displayType) {
                         case StatusDisplayType.MessageDialog:
-                            this.uiState.dialogState.showOKMessageDialog("Export Succeeded", "Export succeeded.");
+                            this.uiState.dialogState.showOKMessageDialog({
+                                title: "Export Succeeded",
+                                message: "Export succeeded.",
+                            });
                             break;
                         case StatusDisplayType.Label:
                             this.uiState.setCustomExportStatus("Export successful.");
@@ -85,10 +88,10 @@ export class AppState {
                 const message = e.message ? e.message : JSON.stringify(e);
                 switch (displayType) {
                     case StatusDisplayType.MessageDialog:
-                        this.uiState.dialogState.showOKMessageDialog(
-                            "Export Error",
-                            `Error in exporting the game. Hit an exception. Exception message: ${message}`
-                        );
+                        this.uiState.dialogState.showOKMessageDialog({
+                            title: "Export Error",
+                            message: `Error in exporting the game. Hit an exception. Exception message: ${message}`,
+                        });
                         break;
                     case StatusDisplayType.Label:
                         this.uiState.setCustomExportStatus(

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -12,7 +12,11 @@ import { ModalVisibilityStatus } from "./ModalVisibilityStatus";
 import { RenameTeamDialogState } from "./RenameTeamDialogState";
 import { ImportFromQBJDialogState } from "./ImportFromQBJDialogState";
 import { AddPlayerDialogState } from "./AddPlayerDialogState";
-import { Cycle } from "./Cycle";
+import {
+    IOKCancelMessageDialogOptions,
+    IOKMessageDialogOptions,
+    IYesNoCancelMessageDialogOptions,
+} from "./IMessageDialogOptions";
 
 export class DialogState {
     @ignore
@@ -174,12 +178,6 @@ export class DialogState {
         this.visibleDialog = ModalVisibilityStatus.ImportFromQBJ;
     }
 
-    public showRemoveTossupProtestDialog(cycle: Cycle, teamName: string): void {
-        this.showOKCancelMessageDialog("Remove protest", `Remove tossup protest for "${teamName}"?`, () => {
-            cycle.removeTossupProtest(teamName);
-        });
-    }
-
     public showRenamePlayerDialog(player: Player): void {
         this.renamePlayerDialog = new RenamePlayerDialogState(player);
         this.visibleDialog = ModalVisibilityStatus.RenamePlayer;
@@ -199,33 +197,37 @@ export class DialogState {
         this.visibleDialog = ModalVisibilityStatus.Scoresheet;
     }
 
-    public showOKMessageDialog(title: string, message: string, onOK?: () => void): void {
+    public showOKMessageDialog(options: IOKMessageDialogOptions): void {
         this.messageDialog = {
-            title,
-            message,
+            title: options.title,
+            message: options.message,
             type: MessageDialogType.OK,
-            onOK,
+            onOK: options.onOK,
+            okLabel: options.okLabel,
         };
         this.visibleDialog = ModalVisibilityStatus.Message;
     }
 
-    public showOKCancelMessageDialog(title: string, message: string, onOK: () => void): void {
+    public showOKCancelMessageDialog(options: IOKCancelMessageDialogOptions): void {
         this.messageDialog = {
-            title,
-            message,
+            title: options.title,
+            message: options.message,
             type: MessageDialogType.OKCancel,
-            onOK,
+            onOK: options.onOK,
+            okLabel: options.okLabel,
         };
         this.visibleDialog = ModalVisibilityStatus.Message;
     }
 
-    public showYesNoCancelMessageDialog(title: string, message: string, onYes: () => void, onNo: () => void): void {
+    public showYesNoCancelMessageDialog(options: IYesNoCancelMessageDialogOptions): void {
         this.messageDialog = {
-            title,
-            message,
+            title: options.title,
+            message: options.message,
             type: MessageDialogType.YesNocCancel,
-            onOK: onYes,
-            onNo: onNo,
+            onOK: options.onYes,
+            onNo: options.onNo,
+            yesLabel: options.yesLabel,
+            noLabel: options.noLabel,
         };
         this.visibleDialog = ModalVisibilityStatus.Message;
     }

--- a/src/state/IMessageDialogOptions.ts
+++ b/src/state/IMessageDialogOptions.ts
@@ -1,0 +1,21 @@
+export interface IMessageDialogOptions {
+    title: string;
+    message: string;
+}
+
+export interface IOKMessageDialogOptions extends IMessageDialogOptions {
+    onOK?: () => void;
+    okLabel?: string;
+}
+
+export interface IOKCancelMessageDialogOptions extends IMessageDialogOptions {
+    onOK: () => void;
+    okLabel?: string;
+}
+
+export interface IYesNoCancelMessageDialogOptions extends IMessageDialogOptions {
+    onYes: () => void;
+    onNo: () => void;
+    yesLabel?: string;
+    noLabel?: string;
+}

--- a/src/state/IMessageDialogState.ts
+++ b/src/state/IMessageDialogState.ts
@@ -4,6 +4,9 @@ export interface IMessageDialogState {
     type: MessageDialogType;
     onOK?: () => void;
     onNo?: () => void;
+    okLabel?: string;
+    yesLabel?: string;
+    noLabel?: string;
 }
 
 export const enum MessageDialogType {

--- a/src/state/UIState.ts
+++ b/src/state/UIState.ts
@@ -544,6 +544,60 @@ export class UIState {
         this.dialogState.visibleDialog = ModalVisibilityStatus.TossupProtest;
     }
 
+    public showRemoveTossupProtestDialog(cycle: Cycle, teamName: string): void {
+        const existingProtest: ITossupProtestEvent | undefined = cycle.tossupProtests?.find(
+            (protest) => protest.teamName === teamName
+        );
+        if (existingProtest == undefined) {
+            return;
+        }
+
+        this.dialogState.showYesNoCancelMessageDialog({
+            title: "Remove protest",
+            message: `Do you want to remove or edit the tossup protest for "${teamName}"?`,
+            yesLabel: "Remove",
+            noLabel: "Edit",
+            onYes: () => {
+                cycle.removeTossupProtest(teamName);
+            },
+            onNo: () => {
+                this.setPendingTossupProtest(teamName, existingProtest.questionIndex, existingProtest.position);
+
+                if (this.pendingTossupProtestEvent != undefined) {
+                    this.pendingTossupProtestEvent.givenAnswer = existingProtest.givenAnswer ?? "";
+                    this.pendingTossupProtestEvent.reason = existingProtest.reason;
+                }
+            },
+        });
+    }
+
+    public showRemoveBonusProtestDialog(cycle: Cycle, partIndex: number): void {
+        const existingProtest: IBonusProtestEvent | undefined = cycle.bonusProtests?.find(
+            (protest) => protest.partIndex === partIndex
+        );
+        if (existingProtest == undefined) {
+            return;
+        }
+
+        this.dialogState.showYesNoCancelMessageDialog({
+            title: "Remove protest",
+            message: `Do you want to remove or edit the bonus protest for part ${partIndex + 1}?`,
+            yesLabel: "Remove",
+            noLabel: "Edit",
+            onYes: () => {
+                cycle.removeBonusProtest(partIndex);
+            },
+            onNo: () => {
+                this.setPendingBonusProtest(existingProtest.teamName, existingProtest.questionIndex, partIndex);
+
+                if (this.pendingBonusProtestEvent != undefined) {
+                    this.pendingBonusProtestEvent.givenAnswer = existingProtest.givenAnswer ?? "";
+                    this.pendingBonusProtestEvent.reason = existingProtest.reason;
+                }
+            },
+        });
+    }
+
     public setPronunciationGuideColor(color: string | undefined): void {
         this.pronunciationGuideColor = color;
     }

--- a/tests/BonusProtestDialogControllerTests.ts
+++ b/tests/BonusProtestDialogControllerTests.ts
@@ -128,6 +128,43 @@ describe("BonusQuestionDialogControllerTests", () => {
         expect(newProtest.teamName).to.equal(defaultTeamNames[1]);
     });
 
+    it("updates existing protest", () => {
+        const originalGivenAnswer = "Original answer";
+        const originalReason = "Original reason";
+        const updatedGivenAnswer = "Updated answer";
+        const updatedReason = "Updated reason";
+
+        const appState: AppState = initializeApp(true);
+        const cycle: Cycle = appState.game.cycles[0];
+
+        // Existing protest for the same bonus/part that commit should update.
+        cycle.addBonusProtest(0, 2, originalGivenAnswer, originalReason, defaultTeamNames[0]);
+
+        if (appState.uiState.pendingBonusProtestEvent == undefined) {
+            assert.fail("Test wasn't initialized correctly");
+        }
+
+        BonusProtestDialogController.changePart(appState, 2);
+
+        appState.uiState.pendingBonusProtestEvent.givenAnswer = updatedGivenAnswer;
+        appState.uiState.pendingBonusProtestEvent.reason = updatedReason;
+
+        BonusProtestDialogController.commit(appState, cycle);
+
+        if (cycle.bonusProtests == undefined) {
+            assert.fail("Bonus protests were undefined");
+        }
+
+        expect(cycle.bonusProtests.length).to.equal(1);
+
+        const updatedProtest = cycle.bonusProtests[0];
+        expect(updatedProtest.questionIndex).to.equal(0);
+        expect(updatedProtest.partIndex).to.equal(2);
+        expect(updatedProtest.teamName).to.equal(defaultTeamNames[0]);
+        expect(updatedProtest.givenAnswer).to.equal(updatedGivenAnswer);
+        expect(updatedProtest.reason).to.equal(updatedReason);
+    });
+
     it("change part", () => {
         const givenAnswer = "My answer";
         const reason = "It is factually wrong";

--- a/tests/DialogStateTests.ts
+++ b/tests/DialogStateTests.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+
+import { DialogState } from "src/state/DialogState";
+import { MessageDialogType } from "src/state/IMessageDialogState";
+import { ModalVisibilityStatus } from "src/state/ModalVisibilityStatus";
+
+describe("DialogStateTests", () => {
+    it("showOKMessageDialog stores message fields and optional OK label", () => {
+        const dialogState: DialogState = new DialogState();
+
+        dialogState.showOKMessageDialog({
+            title: "Info",
+            message: "Done",
+            okLabel: "Got it",
+        });
+
+        expect(dialogState.visibleDialog).to.equal(ModalVisibilityStatus.Message);
+        expect(dialogState.messageDialog).to.not.be.undefined;
+
+        const messageDialog = dialogState.messageDialog;
+        if (messageDialog == undefined) {
+            throw new Error("Message dialog was undefined");
+        }
+
+        expect(messageDialog.type).to.equal(MessageDialogType.OK);
+        expect(messageDialog.title).to.equal("Info");
+        expect(messageDialog.message).to.equal("Done");
+        expect(messageDialog.okLabel).to.equal("Got it");
+        expect(messageDialog.yesLabel).to.be.undefined;
+        expect(messageDialog.noLabel).to.be.undefined;
+    });
+
+    it("showOKCancelMessageDialog stores callback and optional OK label", () => {
+        const dialogState: DialogState = new DialogState();
+        let confirmed = false;
+
+        dialogState.showOKCancelMessageDialog({
+            title: "Confirm",
+            message: "Proceed?",
+            onOK: () => {
+                confirmed = true;
+            },
+            okLabel: "Proceed",
+        });
+
+        expect(dialogState.visibleDialog).to.equal(ModalVisibilityStatus.Message);
+        expect(dialogState.messageDialog).to.not.be.undefined;
+
+        const messageDialog = dialogState.messageDialog;
+        if (messageDialog == undefined || messageDialog.onOK == undefined) {
+            throw new Error("OK/Cancel message dialog was missing onOK callback");
+        }
+
+        expect(messageDialog.type).to.equal(MessageDialogType.OKCancel);
+        expect(messageDialog.okLabel).to.equal("Proceed");
+
+        messageDialog.onOK();
+        expect(confirmed).to.be.true;
+    });
+
+    it("showYesNoCancelMessageDialog stores callbacks and optional labels", () => {
+        const dialogState: DialogState = new DialogState();
+        let yesClicked = false;
+        let noClicked = false;
+
+        dialogState.showYesNoCancelMessageDialog({
+            title: "Export?",
+            message: "Export before leaving?",
+            onYes: () => {
+                yesClicked = true;
+            },
+            onNo: () => {
+                noClicked = true;
+            },
+            yesLabel: "Export",
+            noLabel: "Skip",
+        });
+
+        expect(dialogState.visibleDialog).to.equal(ModalVisibilityStatus.Message);
+        expect(dialogState.messageDialog).to.not.be.undefined;
+
+        const messageDialog = dialogState.messageDialog;
+        if (messageDialog == undefined || messageDialog.onOK == undefined || messageDialog.onNo == undefined) {
+            throw new Error("Yes/No/Cancel message dialog callbacks were missing");
+        }
+
+        expect(messageDialog.type).to.equal(MessageDialogType.YesNocCancel);
+        expect(messageDialog.yesLabel).to.equal("Export");
+        expect(messageDialog.noLabel).to.equal("Skip");
+
+        messageDialog.onOK();
+
+        expect(yesClicked).to.be.true;
+        expect(noClicked).to.be.false;
+
+        messageDialog.onNo();
+
+        expect(yesClicked).to.be.true;
+        expect(noClicked).to.be.true;
+    });
+});

--- a/tests/TossupProtestDialogControllerTests.ts
+++ b/tests/TossupProtestDialogControllerTests.ts
@@ -130,6 +130,41 @@ describe("BonusQuestionDialogControllerTests", () => {
         expect(newProtest.position).to.equal(100);
     });
 
+    it("updates existing protest", () => {
+        const originalGivenAnswer = "Original answer";
+        const originalReason = "Original reason";
+        const updatedGivenAnswer = "Updated answer";
+        const updatedReason = "Updated reason";
+
+        const appState: AppState = initializeApp(true);
+        const cycle: Cycle = appState.game.cycles[0];
+
+        // Existing protest for the same team/question that commit should update.
+        cycle.addTossupProtest(defaultTeamNames[0], 0, 2, originalGivenAnswer, originalReason);
+
+        if (appState.uiState.pendingTossupProtestEvent == undefined) {
+            assert.fail("Test wasn't initialized correctly");
+        }
+
+        appState.uiState.pendingTossupProtestEvent.givenAnswer = updatedGivenAnswer;
+        appState.uiState.pendingTossupProtestEvent.reason = updatedReason;
+
+        TossupProtestDialogController.commit(appState, cycle);
+
+        if (cycle.tossupProtests == undefined) {
+            assert.fail("Tossup protests were undefined");
+        }
+
+        expect(cycle.tossupProtests.length).to.equal(1);
+
+        const updatedProtest = cycle.tossupProtests[0];
+        expect(updatedProtest.teamName).to.equal(defaultTeamNames[0]);
+        expect(updatedProtest.questionIndex).to.equal(0);
+        expect(updatedProtest.position).to.equal(2);
+        expect(updatedProtest.givenAnswer).to.equal(updatedGivenAnswer);
+        expect(updatedProtest.reason).to.equal(updatedReason);
+    });
+
     it("hideDialog", () => {
         const appState: AppState = initializeApp();
         expect(appState.uiState.pendingTossupProtestEvent).to.not.be.undefined;

--- a/tests/UIStateTests.ts
+++ b/tests/UIStateTests.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+
+import { AppState } from "src/state/AppState";
+import { Cycle } from "src/state/Cycle";
+import { MessageDialogType } from "src/state/IMessageDialogState";
+import { ModalVisibilityStatus } from "src/state/ModalVisibilityStatus";
+import { Player } from "src/state/TeamState";
+
+describe("UIStateTests", () => {
+    describe("showRemoveBonusProtestDialog", () => {
+        it("remove callback removes the protest", () => {
+            const appState: AppState = new AppState();
+            const cycle: Cycle = new Cycle();
+            cycle.correctBuzz = {
+                tossupIndex: 2,
+                marker: { player: new Player("Alice", "Alpha", true), position: 17, points: 10 },
+            };
+            cycle.addBonusProtest(2, 1, "alpha answer", "alpha reason", "Alpha");
+
+            appState.uiState.showRemoveBonusProtestDialog(cycle, 1);
+
+            const messageDialog = appState.uiState.dialogState.messageDialog;
+            if (messageDialog == undefined || messageDialog.onOK == undefined) {
+                throw new Error("Remove bonus protest dialog was missing the remove callback");
+            }
+
+            expect(appState.uiState.dialogState.visibleDialog).to.equal(ModalVisibilityStatus.Message);
+            expect(messageDialog.type).to.equal(MessageDialogType.YesNocCancel);
+            expect(messageDialog.yesLabel).to.equal("Remove");
+            expect(messageDialog.noLabel).to.equal("Edit");
+
+            messageDialog.onOK();
+
+            expect(cycle.bonusProtests).to.be.undefined;
+        });
+
+        it("edit callback reopens the protest with existing values", () => {
+            const appState: AppState = new AppState();
+            const cycle: Cycle = new Cycle();
+            cycle.correctBuzz = {
+                tossupIndex: 2,
+                marker: { player: new Player("Alice", "Alpha", true), position: 17, points: 10 },
+            };
+            cycle.addBonusProtest(2, 1, "alpha answer", "alpha reason", "Alpha");
+
+            appState.uiState.showRemoveBonusProtestDialog(cycle, 1);
+
+            const messageDialog = appState.uiState.dialogState.messageDialog;
+            if (messageDialog == undefined || messageDialog.onNo == undefined) {
+                throw new Error("Remove bonus protest dialog was missing the edit callback");
+            }
+
+            messageDialog.onNo();
+
+            const pendingProtest = appState.uiState.pendingBonusProtestEvent;
+            expect(appState.uiState.dialogState.visibleDialog).to.equal(ModalVisibilityStatus.BonusProtest);
+            expect(pendingProtest).to.not.be.undefined;
+
+            if (pendingProtest == undefined) {
+                throw new Error("Pending bonus protest was undefined after choosing edit");
+            }
+
+            expect(pendingProtest.teamName).to.equal("Alpha");
+            expect(pendingProtest.questionIndex).to.equal(2);
+            expect(pendingProtest.partIndex).to.equal(1);
+            expect(pendingProtest.givenAnswer).to.equal("alpha answer");
+            expect(pendingProtest.reason).to.equal("alpha reason");
+        });
+    });
+
+    describe("showRemoveTossupProtestDialog", () => {
+        it("remove callback removes the protest", () => {
+            const appState: AppState = new AppState();
+            const cycle: Cycle = new Cycle();
+            cycle.addTossupProtest("Alpha", 2, 17, "alpha answer", "alpha reason");
+
+            appState.uiState.showRemoveTossupProtestDialog(cycle, "Alpha");
+
+            const messageDialog = appState.uiState.dialogState.messageDialog;
+            if (messageDialog == undefined || messageDialog.onOK == undefined) {
+                throw new Error("Remove tossup protest dialog was missing the remove callback");
+            }
+
+            expect(appState.uiState.dialogState.visibleDialog).to.equal(ModalVisibilityStatus.Message);
+            expect(messageDialog.type).to.equal(MessageDialogType.YesNocCancel);
+            expect(messageDialog.yesLabel).to.equal("Remove");
+            expect(messageDialog.noLabel).to.equal("Edit");
+
+            messageDialog.onOK();
+
+            expect(cycle.tossupProtests).to.be.undefined;
+        });
+
+        it("edit callback reopens the protest with existing values", () => {
+            const appState: AppState = new AppState();
+            const cycle: Cycle = new Cycle();
+            cycle.addTossupProtest("Alpha", 2, 17, "alpha answer", "alpha reason");
+
+            appState.uiState.showRemoveTossupProtestDialog(cycle, "Alpha");
+
+            const messageDialog = appState.uiState.dialogState.messageDialog;
+            if (messageDialog == undefined || messageDialog.onNo == undefined) {
+                throw new Error("Remove tossup protest dialog was missing the edit callback");
+            }
+
+            messageDialog.onNo();
+
+            const pendingProtest = appState.uiState.pendingTossupProtestEvent;
+            expect(appState.uiState.dialogState.visibleDialog).to.equal(ModalVisibilityStatus.TossupProtest);
+            expect(pendingProtest).to.not.be.undefined;
+
+            if (pendingProtest == undefined) {
+                throw new Error("Pending tossup protest was undefined after choosing edit");
+            }
+
+            expect(pendingProtest.teamName).to.equal("Alpha");
+            expect(pendingProtest.questionIndex).to.equal(2);
+            expect(pendingProtest.position).to.equal(17);
+            expect(pendingProtest.givenAnswer).to.equal("alpha answer");
+            expect(pendingProtest.reason).to.equal("alpha reason");
+        });
+    });
+});


### PR DESCRIPTION
- Change the menu item for protesting bonus parts. Users now select individual parts (#384)
- Allow users to edit the protest by clicking on an existing protest (#386)
- Make some changes to what protest info is copied (#372)
- Fix the bug "Selecting a buzz with the keyboard shouldn't reset the focus to the menu" (#293)
- Bump version to 1.40.0