### PR TITLE
react and react-dom now peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
         "mocha": "^10.0.0",
         "@playwright/test": "^1.28.0",
         "prettier": "^2.2.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
         "tsconfig-paths": "^3.9.0",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.3",
@@ -55,9 +57,11 @@
         "he": "^1.2.0",
         "mobx": "^6.5.0",
         "mobx-react-lite": "^3.3.0",
-        "mobx-sync": "^3.0.0",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1"
+        "mobx-sync": "^3.0.0"
+    },
+    "peerDependencies": {
+        "react": "^17.0.1 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.1 || ^18.0.0 || ^19.0.0"
     },
     "resolutions": {
         "@types/react": "17.0.3"


### PR DESCRIPTION
Converts react/react-dom to peerDependencies to fix a runtime duplicate-copy bug observed in TMS (npm was bundling MODAQ's own pinned React 17 alongside the host's React 19, causing a react/react-dom major-version mismatch in the same render tree). Safe for all consumers since sharing a single React instance is required for hooks/context to work correctly regardless of version.

@types/react (still 17) and TypeScript (still 4.2) are intentionally left alone for now. Bumping @types/react to 19 requires TypeScript 5.1+ (for the new JSX namespace re-export mechanism), plus fixing ReactDOM.render (removed in React 19; demo/app.tsx still uses it) and an incompatible ErrorBoundary dependency's stale type definitions. Apps using React 19 (like TMS) may see a tsc type-checking warning about FunctionComponent's return type when rendering ModaqControl, but runtime behavior is unaffected.