### PR TITLE
Context-aware question replacement dialog

### DIFF
--- a/src/components/BonusQuestion.tsx
+++ b/src/components/BonusQuestion.tsx
@@ -67,13 +67,6 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
     }
 
     const disabled = !props.inPlay;
-    const disableThrowOutButton: boolean =
-        disabled ||
-        props.appState.activeGame.cycles.some(
-            (cycle) => cycle.bonusAnswer != undefined && cycle.bonusAnswer.bonusIndex > props.bonusIndex
-        );
-    const throwOutButtonTooltip: string =
-        disableThrowOutButton && !disabled ? "Cannot throw out bonus if future bonuses have events" : "Throw out bonus";
 
     const parts: JSX.Element[] = props.bonus.parts.map((bonusPartProps, index) => {
         return (
@@ -121,8 +114,8 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
                             </StackItem>
                             <StackItem>
                                 <CancelButton
-                                    disabled={disableThrowOutButton}
-                                    tooltip={throwOutButtonTooltip}
+                                    disabled={disabled}
+                                    tooltip="Throw out bonus"
                                     onClick={throwOutClickHandler}
                                 />
                             </StackItem>

--- a/src/components/BonusQuestionController.ts
+++ b/src/components/BonusQuestionController.ts
@@ -3,9 +3,9 @@ import { Cycle } from "../state/Cycle";
 import { getThrowOutQuestionPrompt } from "./ThrowOutQuestionMessage";
 
 export function throwOutBonus(appState: AppState, cycle: Cycle, bonusIndex: number): void {
-    const cycleIndex: number = appState.game.cycles.indexOf(cycle);
+    const cycleIndex: number = appState.activeGame.cycles.indexOf(cycle);
     const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, cycleIndex, "bonus", bonusIndex + 1);
-    const totalBonuses: number = appState.game.packet.bonuses.length;
+    const totalBonuses: number = appState.activeGame.packet.bonuses.length;
     appState.uiState.dialogState.showThrowOutQuestionDialog({
         title: "Throw Out Bonus",
         message: `${message} To undo this, click on the X next to its event in the Event Log.`,

--- a/src/components/BonusQuestionController.ts
+++ b/src/components/BonusQuestionController.ts
@@ -1,14 +1,21 @@
 import { AppState } from "../state/AppState";
 import { Cycle } from "../state/Cycle";
+import { getReplacementQuestionIndex, getThrowOutQuestionMessage } from "./ThrowOutQuestionMessage";
 
 export function throwOutBonus(appState: AppState, cycle: Cycle, bonusIndex: number): void {
-    appState.uiState.dialogState.showOKCancelMessageDialog({
-        title: "Throw out Bonus",
-        message: "Click OK to throw out the bonus. To undo this, click on the X next to its event in the Event Log.",
-        onOK: () => onConfirmThrowOutBonus(cycle, bonusIndex),
+    const cycleIndex: number = appState.game.cycles.indexOf(cycle);
+    const replacementIndex: number | undefined = getReplacementQuestionIndex(appState, cycleIndex, "bonus", bonusIndex + 1);
+    const message: string = getThrowOutQuestionMessage(appState, cycleIndex, "bonus", bonusIndex + 1);
+    const totalBonuses: number = appState.game.packet.bonuses.length;
+    appState.uiState.dialogState.showThrowOutQuestionDialog({
+        title: "Throw Out Bonus",
+        message: `${message} To undo this, click on the X next to its event in the Event Log.`,
+        defaultReplacementNumber: replacementIndex != undefined ? replacementIndex + 1 : undefined,
+        maxQuestionNumber: totalBonuses,
+        onConfirm: (userReplacementIndex) => onConfirmThrowOutBonus(cycle, bonusIndex, userReplacementIndex),
     });
 }
 
-function onConfirmThrowOutBonus(cycle: Cycle, bonusIndex: number) {
-    cycle.addThrownOutBonus(bonusIndex);
+function onConfirmThrowOutBonus(cycle: Cycle, bonusIndex: number, replacementIndex: number | undefined) {
+    cycle.addThrownOutBonus(bonusIndex, replacementIndex);
 }

--- a/src/components/BonusQuestionController.ts
+++ b/src/components/BonusQuestionController.ts
@@ -1,11 +1,10 @@
 import { AppState } from "../state/AppState";
 import { Cycle } from "../state/Cycle";
-import { getReplacementQuestionIndex, getThrowOutQuestionMessage } from "./ThrowOutQuestionMessage";
+import { getThrowOutQuestionPrompt } from "./ThrowOutQuestionMessage";
 
 export function throwOutBonus(appState: AppState, cycle: Cycle, bonusIndex: number): void {
     const cycleIndex: number = appState.game.cycles.indexOf(cycle);
-    const replacementIndex: number | undefined = getReplacementQuestionIndex(appState, cycleIndex, "bonus", bonusIndex + 1);
-    const message: string = getThrowOutQuestionMessage(appState, cycleIndex, "bonus", bonusIndex + 1);
+    const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, cycleIndex, "bonus", bonusIndex + 1);
     const totalBonuses: number = appState.game.packet.bonuses.length;
     appState.uiState.dialogState.showThrowOutQuestionDialog({
         title: "Throw Out Bonus",

--- a/src/components/ModalDialogContainer.tsx
+++ b/src/components/ModalDialogContainer.tsx
@@ -19,6 +19,7 @@ import { AppState } from "../state/AppState";
 import { ModalVisibilityStatus } from "../state/ModalVisibilityStatus";
 import { RenameTeamDialog } from "./dialogs/RenameTeamDialog";
 import { ImportFromQBJDialog } from "./dialogs/ImportFromQBJDialog";
+import { ThrowOutQuestionDialog } from "./dialogs/ThrowOutQuestionDialog";
 
 export const ModalDialogContainer = observer(function ModalDialogContainer() {
     // The Protest dialogs aren't here because they require extra information
@@ -44,6 +45,7 @@ export const ModalDialogContainer = observer(function ModalDialogContainer() {
             <RenameTeamDialog />
             <ReorderPlayerDialog />
             <ScoresheetDialog />
+            <ThrowOutQuestionDialog />
         </>
     );
 });

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -26,40 +26,27 @@ function getScenario(
     return hasGameDataAfter ? "protest" : "procedural";
 }
 
-// Returns the 0-based packet index of the replacement question, or undefined if no replacement is available
-// (i.e. the packet has no more questions). Protest replacements pull from the end of the packet;
-// tiebreaker and procedural replacements use the next sequential question.
-export function getReplacementQuestionIndex(
-    appState: AppState,
-    cycleIndex: number,
-    questionType: ThrowOutQuestionType,
-    currentQuestionNumber: number // 1-based
-): number | undefined {
-    const gameFormat: IGameFormat = appState.game.gameFormat;
-    const totalQuestionCount: number =
-        questionType === "tossup" ? appState.game.packet.tossups.length : appState.game.packet.bonuses.length;
-    const nextQuestionNumber: number = currentQuestionNumber + 1;
-    const needsMoreQuestions: boolean = nextQuestionNumber > totalQuestionCount;
-
-    if (needsMoreQuestions) {
-        return undefined;
-    }
-
-    const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);
-    // Protest replacements use the last question in the packet (0-based); others use the next sequential question.
-    return scenario === "protest" ? totalQuestionCount - 1 : nextQuestionNumber - 1;
+export interface IThrowOutQuestionPrompt {
+    // The confirmation message shown before throwing out the question.
+    message: string;
+    // The 0-based packet index of the replacement question, or undefined if no replacement is available
+    // (i.e. the packet has no more questions).
+    replacementIndex: number | undefined;
 }
 
-// Picks the confirmation message shown before throwing out a question, based on where in the game it falls:
+// Builds the confirmation prompt shown before throwing out a question. Both the message and the replacement
+// index are derived from the same scenario, based on where in the game the question falls:
 // - The single tiebreaker tossup (standard formats that replace it, rather than appending more tiebreakers, e.g. NAQT)
 // - Mid-match with no recorded events afterward (likely a moderator procedural error)
 // - Mid-match with recorded events afterward (likely a protest resolution)
-export function getThrowOutQuestionMessage(
+// Protest replacements pull from the end of the packet; tiebreaker and procedural replacements use the next
+// sequential question.
+export function getThrowOutQuestionPrompt(
     appState: AppState,
     cycleIndex: number,
     questionType: ThrowOutQuestionType,
     currentQuestionNumber: number // 1-based
-): string {
+): IThrowOutQuestionPrompt {
     const gameFormat: IGameFormat = appState.game.gameFormat;
     const nextQuestionNumber: number = currentQuestionNumber + 1;
     const totalQuestionCount: number =
@@ -68,25 +55,35 @@ export function getThrowOutQuestionMessage(
 
     const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);
 
+    let replacementIndex: number | undefined;
+    if (needsMoreQuestions) {
+        replacementIndex = undefined;
+    } else if (scenario === "protest") {
+        replacementIndex = totalQuestionCount - 1;
+    } else {
+        replacementIndex = nextQuestionNumber - 1;
+    }
+
+    let message: string;
     if (scenario === "tiebreaker") {
-        return needsMoreQuestions
+        message = needsMoreQuestions
             ? "This question is about to be thrown out, which normally happens due to a tiebreaker tossup going " +
-                  "unanswered. Additional questions need to be uploaded before it can be replaced."
+              "unanswered. Additional questions need to be uploaded before it can be replaced."
             : "This question is about to be thrown out, which normally happens due to a tiebreaker tossup going " +
-                  `unanswered, and will be replaced with tossup ${nextQuestionNumber}.`;
-    }
-
-    if (scenario === "protest") {
-        return needsMoreQuestions
+              `unanswered, and will be replaced with tossup ${nextQuestionNumber}.`;
+    } else if (scenario === "protest") {
+        message = needsMoreQuestions
             ? "This question is about to be thrown out, which typically is due to protest resolution and potential " +
-                  "further gameplay. Additional questions need to be uploaded before it can be replaced."
+              "further gameplay. Additional questions need to be uploaded before it can be replaced."
             : `This question is about to be thrown out and replaced with ${questionType} ${totalQuestionCount}, ` +
-                  "which typically is due to protest resolution and potential further gameplay.";
+              "which typically is due to protest resolution and potential further gameplay.";
+    } else {
+        message = needsMoreQuestions
+            ? "This question is about to be thrown out, which normally happens due to a moderator procedural error. " +
+              "Additional questions need to be uploaded before it can be replaced. Is that your intended action?"
+            : `This question is about to be thrown out and replaced with ${questionType} ${nextQuestionNumber}, ` +
+              "which normally happens due to a moderator procedural error. Is that your intended action?";
     }
 
-    return needsMoreQuestions
-        ? "This question is about to be thrown out, which normally happens due to a moderator procedural error. " +
-              "Additional questions need to be uploaded before it can be replaced. Is that your intended action?"
-        : `This question is about to be thrown out and replaced with ${questionType} ${nextQuestionNumber}, ` +
-              "which normally happens due to a moderator procedural error. Is that your intended action?";
+    return { message, replacementIndex };
 }

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -20,9 +20,11 @@ function getScenario(
         return "tiebreaker";
     }
 
+    // A bonus is only ever recorded after a correct tossup buzz, so a defined bonusAnswer always implies a
+    // non-empty orderedBuzzes; checking the buzzes alone is sufficient to detect game data after this cycle.
     const hasGameDataAfter: boolean = appState.activeGame.cycles
         .slice(cycleIndex + 1)
-        .some((cycle: Cycle) => cycle.orderedBuzzes.length > 0 || cycle.bonusAnswer != undefined);
+        .some((cycle: Cycle) => cycle.orderedBuzzes.length > 0);
     return hasGameDataAfter ? "protest" : "procedural";
 }
 

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -12,9 +12,14 @@ function getScenario(
     questionType: ThrowOutQuestionType,
     gameFormat: IGameFormat
 ): ThrowOutScenario {
+    // Cycles 0 through regulationTossupCount - 1 are regulation, so any cycle at or beyond
+    // regulationTossupCount is an overtime tossup. minimumOvertimeQuestionCount === 1 identifies
+    // sudden-death overtime, which is played one tossup at a time, so every overtime tossup in those
+    // formats is a tiebreaker. Formats that play a fixed block of overtime questions (e.g. NAQT's three)
+    // aren't sudden death, so their overtime tossups fall through to the protest/procedural cases.
     const isTiebreakerTossup: boolean =
         questionType === "tossup" &&
-        cycleIndex === gameFormat.regulationTossupCount &&
+        cycleIndex >= gameFormat.regulationTossupCount &&
         gameFormat.minimumOvertimeQuestionCount === 1;
     if (isTiebreakerTossup) {
         return "tiebreaker";
@@ -38,7 +43,7 @@ export interface IThrowOutQuestionPrompt {
 
 // Builds the confirmation prompt shown before throwing out a question. Both the message and the replacement
 // index are derived from the same scenario, based on where in the game the question falls:
-// - The single tiebreaker tossup (standard formats that replace it, rather than appending more tiebreakers, e.g. NAQT)
+// - An overtime tiebreaker tossup (sudden-death formats, which play overtime one tossup at a time)
 // - Mid-match with no recorded events afterward (likely a moderator procedural error)
 // - Mid-match with recorded events afterward (likely a protest resolution)
 // Protest replacements pull from the end of the packet; tiebreaker and procedural replacements use the next

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -1,0 +1,92 @@
+import { AppState } from "../state/AppState";
+import { Cycle } from "../state/Cycle";
+import { IGameFormat } from "../state/IGameFormat";
+
+export type ThrowOutQuestionType = "tossup" | "bonus";
+
+type ThrowOutScenario = "tiebreaker" | "protest" | "procedural";
+
+function getScenario(
+    appState: AppState,
+    cycleIndex: number,
+    questionType: ThrowOutQuestionType,
+    gameFormat: IGameFormat
+): ThrowOutScenario {
+    const isTiebreakerTossup: boolean =
+        questionType === "tossup" &&
+        cycleIndex === gameFormat.regulationTossupCount &&
+        gameFormat.minimumOvertimeQuestionCount === 1;
+    if (isTiebreakerTossup) {
+        return "tiebreaker";
+    }
+
+    const hasGameDataAfter: boolean = appState.game.cycles
+        .slice(cycleIndex + 1)
+        .some((cycle: Cycle) => cycle.orderedBuzzes.length > 0 || cycle.bonusAnswer != undefined);
+    return hasGameDataAfter ? "protest" : "procedural";
+}
+
+// Returns the 0-based packet index of the replacement question, or undefined if no replacement is available
+// (i.e. the packet has no more questions). Protest replacements pull from the end of the packet;
+// tiebreaker and procedural replacements use the next sequential question.
+export function getReplacementQuestionIndex(
+    appState: AppState,
+    cycleIndex: number,
+    questionType: ThrowOutQuestionType,
+    currentQuestionNumber: number // 1-based
+): number | undefined {
+    const gameFormat: IGameFormat = appState.game.gameFormat;
+    const totalQuestionCount: number =
+        questionType === "tossup" ? appState.game.packet.tossups.length : appState.game.packet.bonuses.length;
+    const nextQuestionNumber: number = currentQuestionNumber + 1;
+    const needsMoreQuestions: boolean = nextQuestionNumber > totalQuestionCount;
+
+    if (needsMoreQuestions) {
+        return undefined;
+    }
+
+    const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);
+    // Protest replacements use the last question in the packet (0-based); others use the next sequential question.
+    return scenario === "protest" ? totalQuestionCount - 1 : nextQuestionNumber - 1;
+}
+
+// Picks the confirmation message shown before throwing out a question, based on where in the game it falls:
+// - The single tiebreaker tossup (standard formats that replace it, rather than appending more tiebreakers, e.g. NAQT)
+// - Mid-match with no recorded events afterward (likely a moderator procedural error)
+// - Mid-match with recorded events afterward (likely a protest resolution)
+export function getThrowOutQuestionMessage(
+    appState: AppState,
+    cycleIndex: number,
+    questionType: ThrowOutQuestionType,
+    currentQuestionNumber: number // 1-based
+): string {
+    const gameFormat: IGameFormat = appState.game.gameFormat;
+    const nextQuestionNumber: number = currentQuestionNumber + 1;
+    const totalQuestionCount: number =
+        questionType === "tossup" ? appState.game.packet.tossups.length : appState.game.packet.bonuses.length;
+    const needsMoreQuestions: boolean = nextQuestionNumber > totalQuestionCount;
+
+    const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);
+
+    if (scenario === "tiebreaker") {
+        return needsMoreQuestions
+            ? "This question is about to be thrown out, which normally happens due to a tiebreaker tossup going " +
+                  "unanswered. Additional questions need to be uploaded before it can be replaced."
+            : "This question is about to be thrown out, which normally happens due to a tiebreaker tossup going " +
+                  `unanswered, and will be replaced with tossup ${nextQuestionNumber}.`;
+    }
+
+    if (scenario === "protest") {
+        return needsMoreQuestions
+            ? "This question is about to be thrown out, which typically is due to protest resolution and potential " +
+                  "further gameplay. Additional questions need to be uploaded before it can be replaced."
+            : `This question is about to be thrown out and replaced with ${questionType} ${totalQuestionCount}, ` +
+                  "which typically is due to protest resolution and potential further gameplay.";
+    }
+
+    return needsMoreQuestions
+        ? "This question is about to be thrown out, which normally happens due to a moderator procedural error. " +
+              "Additional questions need to be uploaded before it can be replaced. Is that your intended action?"
+        : `This question is about to be thrown out and replaced with ${questionType} ${nextQuestionNumber}, ` +
+              "which normally happens due to a moderator procedural error. Is that your intended action?";
+}

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -20,7 +20,7 @@ function getScenario(
         return "tiebreaker";
     }
 
-    const hasGameDataAfter: boolean = appState.game.cycles
+    const hasGameDataAfter: boolean = appState.activeGame.cycles
         .slice(cycleIndex + 1)
         .some((cycle: Cycle) => cycle.orderedBuzzes.length > 0 || cycle.bonusAnswer != undefined);
     return hasGameDataAfter ? "protest" : "procedural";
@@ -47,10 +47,10 @@ export function getThrowOutQuestionPrompt(
     questionType: ThrowOutQuestionType,
     currentQuestionNumber: number // 1-based
 ): IThrowOutQuestionPrompt {
-    const gameFormat: IGameFormat = appState.game.gameFormat;
+    const gameFormat: IGameFormat = appState.activeGame.gameFormat;
     const nextQuestionNumber: number = currentQuestionNumber + 1;
     const totalQuestionCount: number =
-        questionType === "tossup" ? appState.game.packet.tossups.length : appState.game.packet.bonuses.length;
+        questionType === "tossup" ? appState.activeGame.packet.tossups.length : appState.activeGame.packet.bonuses.length;
     const needsMoreQuestions: boolean = nextQuestionNumber > totalQuestionCount;
 
     const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);

--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -12,15 +12,18 @@ function getScenario(
     questionType: ThrowOutQuestionType,
     gameFormat: IGameFormat
 ): ThrowOutScenario {
-    // Cycles 0 through regulationTossupCount - 1 are regulation, so any cycle at or beyond
-    // regulationTossupCount is an overtime tossup. minimumOvertimeQuestionCount === 1 identifies
-    // sudden-death overtime, which is played one tossup at a time, so every overtime tossup in those
-    // formats is a tiebreaker. Formats that play a fixed block of overtime questions (e.g. NAQT's three)
-    // aren't sudden death, so their overtime tossups fall through to the protest/procedural cases.
+    // Cycles 0 through regulationTossupCount - 1 are regulation, so any cycle at or beyond regulationTossupCount is
+    // an overtime tossup. A tiebreaker is a sudden-death tossup, played one at a time until the tie breaks:
+    // - Standard formats (minimumOvertimeQuestionCount <= 1) are sudden death from the first overtime tossup, so
+    //   every overtime tossup is a tiebreaker.
+    // - Fixed-block formats (e.g. NAQT's three) read a minimumOvertimeQuestionCount block regardless of the score
+    //   before going to sudden death, so tossups within that block fall through to the protest/procedural cases and
+    //   only tossups past the block are tiebreakers.
     const isTiebreakerTossup: boolean =
         questionType === "tossup" &&
         cycleIndex >= gameFormat.regulationTossupCount &&
-        gameFormat.minimumOvertimeQuestionCount === 1;
+        (gameFormat.minimumOvertimeQuestionCount <= 1 ||
+            cycleIndex >= gameFormat.regulationTossupCount + gameFormat.minimumOvertimeQuestionCount);
     if (isTiebreakerTossup) {
         return "tiebreaker";
     }

--- a/src/components/TossupQuestion.tsx
+++ b/src/components/TossupQuestion.tsx
@@ -30,13 +30,6 @@ export const TossupQuestion = observer(function TossupQuestion(props: IQuestionP
         }
     }
 
-    const disableThrowOutButton: boolean = props.appState.activeGame.cycles.some(
-        (cycle) => cycle.orderedBuzzes.length > 0 && cycle.orderedBuzzes[0].tossupIndex + 1 > props.tossupNumber
-    );
-    const throwOutButtonTooltip: string = disableThrowOutButton
-        ? "Cannot throw out tossup if future tossups have events"
-        : "Throw out tossup";
-
     const correctBuzzIndex: number = props.cycle.correctBuzz?.marker.position ?? -1;
     const wrongBuzzIndexes: number[] = (props.cycle.wrongBuzzes ?? [])
         .filter((buzz) => buzz.tossupIndex === props.tossupNumber - 1)
@@ -89,11 +82,7 @@ export const TossupQuestion = observer(function TossupQuestion(props: IQuestionP
                 <PostQuestionMetadata metadata={props.tossup.metadata} />
             </div>
             <div>
-                <CancelButton
-                    disabled={disableThrowOutButton}
-                    tooltip={throwOutButtonTooltip}
-                    onClick={throwOutClickHandler}
-                />
+                <CancelButton tooltip="Throw out tossup" onClick={throwOutClickHandler} />
             </div>
         </div>
     );

--- a/src/components/TossupQuestionController.ts
+++ b/src/components/TossupQuestionController.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { AppState } from "../state/AppState";
 import { Cycle } from "../state/Cycle";
 import { UIState } from "../state/UIState";
+import { getReplacementQuestionIndex, getThrowOutQuestionMessage } from "./ThrowOutQuestionMessage";
 
 export function selectWordFromClick(appState: AppState, event: React.MouseEvent<HTMLDivElement>): void {
     const target = event.target as HTMLDivElement;
@@ -47,14 +48,20 @@ export function selectWordFromKeyboardEvent(appState: AppState, event: React.Key
 }
 
 export function throwOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number): void {
-    appState.uiState.dialogState.showOKCancelMessageDialog({
-        title: "Throw out Tossup",
-        message: "Click OK to throw out the tossup. To undo this, click on the X next to its event in the Event Log.",
-        onOK: () => onConfirmThrowOutTossup(appState, cycle, tossupNumber),
+    const cycleIndex: number = appState.game.cycles.indexOf(cycle);
+    const replacementIndex: number | undefined = getReplacementQuestionIndex(appState, cycleIndex, "tossup", tossupNumber);
+    const message: string = getThrowOutQuestionMessage(appState, cycleIndex, "tossup", tossupNumber);
+    const totalTossups: number = appState.game.packet.tossups.length;
+    appState.uiState.dialogState.showThrowOutQuestionDialog({
+        title: "Throw Out Tossup",
+        message: `${message} To undo this, click on the X next to its event in the Event Log.`,
+        defaultReplacementNumber: replacementIndex != undefined ? replacementIndex + 1 : undefined,
+        maxQuestionNumber: totalTossups,
+        onConfirm: (userReplacementIndex) => onConfirmThrowOutTossup(appState, cycle, tossupNumber, userReplacementIndex),
     });
 }
 
-function onConfirmThrowOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number) {
-    cycle.addThrownOutTossup(tossupNumber - 1);
+function onConfirmThrowOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number, replacementIndex: number | undefined) {
+    cycle.addThrownOutTossup(tossupNumber - 1, replacementIndex);
     appState.uiState.setSelectedWordIndex(-1);
 }

--- a/src/components/TossupQuestionController.ts
+++ b/src/components/TossupQuestionController.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { AppState } from "../state/AppState";
 import { Cycle } from "../state/Cycle";
 import { UIState } from "../state/UIState";
-import { getReplacementQuestionIndex, getThrowOutQuestionMessage } from "./ThrowOutQuestionMessage";
+import { getThrowOutQuestionPrompt } from "./ThrowOutQuestionMessage";
 
 export function selectWordFromClick(appState: AppState, event: React.MouseEvent<HTMLDivElement>): void {
     const target = event.target as HTMLDivElement;
@@ -49,8 +49,7 @@ export function selectWordFromKeyboardEvent(appState: AppState, event: React.Key
 
 export function throwOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number): void {
     const cycleIndex: number = appState.game.cycles.indexOf(cycle);
-    const replacementIndex: number | undefined = getReplacementQuestionIndex(appState, cycleIndex, "tossup", tossupNumber);
-    const message: string = getThrowOutQuestionMessage(appState, cycleIndex, "tossup", tossupNumber);
+    const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, cycleIndex, "tossup", tossupNumber);
     const totalTossups: number = appState.game.packet.tossups.length;
     appState.uiState.dialogState.showThrowOutQuestionDialog({
         title: "Throw Out Tossup",

--- a/src/components/TossupQuestionController.ts
+++ b/src/components/TossupQuestionController.ts
@@ -48,9 +48,9 @@ export function selectWordFromKeyboardEvent(appState: AppState, event: React.Key
 }
 
 export function throwOutTossup(appState: AppState, cycle: Cycle, tossupNumber: number): void {
-    const cycleIndex: number = appState.game.cycles.indexOf(cycle);
+    const cycleIndex: number = appState.activeGame.cycles.indexOf(cycle);
     const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, cycleIndex, "tossup", tossupNumber);
-    const totalTossups: number = appState.game.packet.tossups.length;
+    const totalTossups: number = appState.activeGame.packet.tossups.length;
     appState.uiState.dialogState.showThrowOutQuestionDialog({
         title: "Throw Out Tossup",
         message: `${message} To undo this, click on the X next to its event in the Event Log.`,

--- a/src/components/dialogs/ThrowOutQuestionDialog.tsx
+++ b/src/components/dialogs/ThrowOutQuestionDialog.tsx
@@ -90,10 +90,6 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
             onDismiss={closeHandler}
         >
             <Label>{dialogState.message}</Label>
-            <div className={classNames.buttonRow}>
-                <PrimaryButton text="Confirm" onClick={confirmHandler} />
-                <DefaultButton text="Cancel" onClick={closeHandler} />
-            </div>
             <Separator />
             <ActionButton
                 iconProps={{ iconName: showCustomInput ? "ChevronDown" : "ChevronRight" }}
@@ -103,6 +99,10 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
                 Use a different replacement question
             </ActionButton>
             {showCustomInput && customInputSection}
+            <div className={classNames.buttonRow}>
+                <PrimaryButton text="Confirm" onClick={confirmHandler} />
+                <DefaultButton text="Cancel" onClick={closeHandler} />
+            </div>
         </ModalDialog>
     );
 });

--- a/src/components/dialogs/ThrowOutQuestionDialog.tsx
+++ b/src/components/dialogs/ThrowOutQuestionDialog.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { observer } from "mobx-react-lite";
+import {
+    Label,
+    PrimaryButton,
+    DefaultButton,
+    SpinButton,
+    Separator,
+    ActionButton,
+    mergeStyleSets,
+} from "@fluentui/react";
+
+import { AppState } from "../../state/AppState";
+import { useAppState } from "../../contexts/StateContext";
+import { IThrowOutQuestionDialogState } from "../../state/DialogState";
+import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
+import { ModalDialog } from "./ModalDialog";
+
+export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog(): JSX.Element {
+    const appState: AppState = useAppState();
+    const dialogState: IThrowOutQuestionDialogState | undefined =
+        appState.uiState.dialogState.throwOutQuestionDialog;
+
+    const [replacementNumber, setReplacementNumber] = React.useState<number | undefined>(
+        dialogState?.defaultReplacementNumber
+    );
+    const [showCustomInput, setShowCustomInput] = React.useState(false);
+
+    // Sync local state when dialog opens with a new default
+    const prevDefault = React.useRef(dialogState?.defaultReplacementNumber);
+    if (prevDefault.current !== dialogState?.defaultReplacementNumber) {
+        prevDefault.current = dialogState?.defaultReplacementNumber;
+        setReplacementNumber(dialogState?.defaultReplacementNumber);
+        setShowCustomInput(false);
+    }
+
+    if (dialogState == undefined) {
+        return <></>;
+    }
+
+    const classes = getClassNames();
+    const closeHandler = (): void => hideDialog(appState);
+
+    const confirmHandler = (): void => {
+        // Convert 1-based display number to 0-based packet index
+        dialogState.onConfirm(replacementNumber != undefined ? replacementNumber - 1 : undefined);
+        hideDialog(appState);
+    };
+
+    const customInputSection: JSX.Element = dialogState.defaultReplacementNumber != undefined ? (
+        <SpinButton
+            label="Replacement question number"
+            min={1}
+            max={dialogState.maxQuestionNumber}
+            value={replacementNumber?.toString() ?? ""}
+            onValidate={(value) => {
+                const parsed = parseInt(value, 10);
+                if (!isNaN(parsed) && parsed >= 1 && parsed <= dialogState.maxQuestionNumber) {
+                    setReplacementNumber(parsed);
+                    return parsed.toString();
+                }
+                return (replacementNumber ?? dialogState.defaultReplacementNumber)?.toString() ?? "";
+            }}
+            onIncrement={(value) => {
+                const parsed = parseInt(value, 10);
+                const next = Math.min((isNaN(parsed) ? 1 : parsed) + 1, dialogState.maxQuestionNumber);
+                setReplacementNumber(next);
+                return next.toString();
+            }}
+            onDecrement={(value) => {
+                const parsed = parseInt(value, 10);
+                const prev = Math.max((isNaN(parsed) ? 1 : parsed) - 1, 1);
+                setReplacementNumber(prev);
+                return prev.toString();
+            }}
+            styles={{ root: { marginTop: 8 } }}
+        />
+    ) : (
+        <Label styles={{ root: { marginTop: 8, fontStyle: "italic" } }}>
+            No replacement available — upload additional questions before confirming.
+        </Label>
+    );
+
+    return (
+        <ModalDialog
+            title={dialogState.title}
+            visibilityStatus={ModalVisibilityStatus.ThrowOutQuestion}
+            maxWidth="30vw"
+            onDismiss={closeHandler}
+        >
+            <Label>{dialogState.message}</Label>
+            <div className={classes.buttonRow}>
+                <PrimaryButton text="Confirm" onClick={confirmHandler} />
+                <DefaultButton text="Cancel" onClick={closeHandler} />
+            </div>
+            <Separator />
+            <ActionButton
+                iconProps={{ iconName: showCustomInput ? "ChevronDown" : "ChevronRight" }}
+                onClick={() => setShowCustomInput(!showCustomInput)}
+                className={classes.toggleButton}
+            >
+                Use a different replacement question
+            </ActionButton>
+            {showCustomInput && customInputSection}
+        </ModalDialog>
+    );
+});
+
+function hideDialog(appState: AppState): void {
+    appState.uiState.dialogState.hideThrowOutQuestionDialog();
+}
+
+interface IThrowOutQuestionDialogClassNames {
+    buttonRow: string;
+    toggleButton: string;
+}
+
+const getClassNames = (): IThrowOutQuestionDialogClassNames =>
+    mergeStyleSets({
+        buttonRow: {
+            display: "flex",
+            gap: 8,
+            marginTop: 16,
+            marginBottom: 8,
+        },
+        toggleButton: {
+            display: "block",
+            height: 24,
+            padding: 0,
+            textAlign: "left",
+        },
+    });

--- a/src/components/dialogs/ThrowOutQuestionDialog.tsx
+++ b/src/components/dialogs/ThrowOutQuestionDialog.tsx
@@ -8,6 +8,8 @@ import {
     Separator,
     ActionButton,
     mergeStyleSets,
+    ILabelStyles,
+    ISpinButtonStyles,
 } from "@fluentui/react";
 
 import { AppState } from "../../state/AppState";
@@ -38,7 +40,6 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
         return <></>;
     }
 
-    const classes = getClassNames();
     const closeHandler = (): void => hideDialog(appState);
 
     const confirmHandler = (): void => {
@@ -73,10 +74,10 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
                 setReplacementNumber(prev);
                 return prev.toString();
             }}
-            styles={{ root: { marginTop: 8 } }}
+            styles={spinButtonStyles}
         />
     ) : (
-        <Label styles={{ root: { marginTop: 8, fontStyle: "italic" } }}>
+        <Label styles={noReplacementLabelStyles}>
             No replacement available — upload additional questions before confirming.
         </Label>
     );
@@ -89,7 +90,7 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
             onDismiss={closeHandler}
         >
             <Label>{dialogState.message}</Label>
-            <div className={classes.buttonRow}>
+            <div className={classNames.buttonRow}>
                 <PrimaryButton text="Confirm" onClick={confirmHandler} />
                 <DefaultButton text="Cancel" onClick={closeHandler} />
             </div>
@@ -97,7 +98,7 @@ export const ThrowOutQuestionDialog = observer(function ThrowOutQuestionDialog()
             <ActionButton
                 iconProps={{ iconName: showCustomInput ? "ChevronDown" : "ChevronRight" }}
                 onClick={() => setShowCustomInput(!showCustomInput)}
-                className={classes.toggleButton}
+                className={classNames.toggleButton}
             >
                 Use a different replacement question
             </ActionButton>
@@ -110,23 +111,23 @@ function hideDialog(appState: AppState): void {
     appState.uiState.dialogState.hideThrowOutQuestionDialog();
 }
 
-interface IThrowOutQuestionDialogClassNames {
-    buttonRow: string;
-    toggleButton: string;
-}
+const classNames = mergeStyleSets({
+    buttonRow: {
+        display: "flex",
+        gap: 8,
+        marginTop: 16,
+        marginBottom: 8,
+    },
+    toggleButton: {
+        display: "block",
+        height: 24,
+        padding: 0,
+        textAlign: "left",
+    },
+});
 
-const getClassNames = (): IThrowOutQuestionDialogClassNames =>
-    mergeStyleSets({
-        buttonRow: {
-            display: "flex",
-            gap: 8,
-            marginTop: 16,
-            marginBottom: 8,
-        },
-        toggleButton: {
-            display: "block",
-            height: 24,
-            padding: 0,
-            textAlign: "left",
-        },
-    });
+const spinButtonStyles: Partial<ISpinButtonStyles> = { root: { marginTop: 8 } };
+
+const noReplacementLabelStyles: Partial<ILabelStyles> = {
+    root: { marginTop: 8, fontStyle: "italic" },
+};

--- a/src/components/dialogs/ThrowOutQuestionDialog.tsx
+++ b/src/components/dialogs/ThrowOutQuestionDialog.tsx
@@ -14,7 +14,7 @@ import {
 
 import { AppState } from "../../state/AppState";
 import { useAppState } from "../../contexts/StateContext";
-import { IThrowOutQuestionDialogState } from "../../state/DialogState";
+import { IThrowOutQuestionDialogState } from "../../state/IThrowOutQuestionDialogState";
 import { ModalVisibilityStatus } from "../../state/ModalVisibilityStatus";
 import { ModalDialog } from "./ModalDialog";
 

--- a/src/qbj/QBJ.ts
+++ b/src/qbj/QBJ.ts
@@ -332,6 +332,21 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
         // The tossup actually read (and buzzed on) is the protest replacement when present, otherwise the scheduled one.
         const playedTossupIndex: number = protestReplacementIndex ?? scheduledTossupIndex;
 
+        // Bonuses mirror the tossup logic: a protest bonus replacement records the answered bonus in replacement_bonus
+        // (the one actually read) while bonus keeps the scheduled number as a bare marker. Detect the protest the same
+        // way, by the two bonus numbers differing.
+        const scheduledBonusIndex: number | undefined =
+            question.bonus?.question != undefined ? question.bonus.question.question_number - 1 : undefined;
+        const protestBonusReplacementIndex: number | undefined =
+            question.replacement_bonus?.question != undefined &&
+            question.bonus?.question != undefined &&
+            question.replacement_bonus.question.question_number !== question.bonus.question.question_number
+                ? question.replacement_bonus.question.question_number - 1
+                : undefined;
+        // The bonus actually read and answered is the protest replacement when present, otherwise the scheduled bonus.
+        const playedBonus: IMatchQuestionBonus | undefined =
+            protestBonusReplacementIndex != undefined ? question.replacement_bonus : question.bonus;
+
         // The correct buzz needs to be added after throwing out any tossups, so we have to delay adding it to the cycle
         let addCorrectBuzzEvent: undefined | (() => void);
 
@@ -401,9 +416,9 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
             if (buzz.result.value > 0) {
                 let bonusQuestionNumber: number | undefined;
                 let bonusQuestionPartsLength: number | undefined;
-                if (question.bonus && question.bonus.question) {
-                    bonusQuestionNumber = question.bonus.question.question_number - 1;
-                    bonusQuestionPartsLength = question.bonus.parts.length;
+                if (playedBonus && playedBonus.question) {
+                    bonusQuestionNumber = playedBonus.question.question_number - 1;
+                    bonusQuestionPartsLength = playedBonus.parts.length;
                 }
 
                 correctTeamName = buzz.team.name;
@@ -446,13 +461,19 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
             addCorrectBuzzEvent();
         }
 
-        for (let j = previousBonusIndex + 1; j < latestBonusIndex; j++) {
-            cycle.addThrownOutBonus(j);
+        if (protestBonusReplacementIndex != undefined && scheduledBonusIndex != undefined) {
+            // A protest bonus replacement was recorded: rebuild it directly so getBonusIndex returns that bonus.
+            // Like tossups, protest replacements don't shift the sequential order, so we don't infer gap throw-outs.
+            cycle.addThrownOutBonus(scheduledBonusIndex, protestBonusReplacementIndex);
+        } else {
+            for (let j = previousBonusIndex + 1; j < latestBonusIndex; j++) {
+                cycle.addThrownOutBonus(j);
+            }
         }
 
-        if (question.bonus && question.bonus.question && question.bonus.parts && correctTeamName) {
-            for (let j = 0; j < question.bonus.parts.length; j++) {
-                const part = question.bonus.parts[j];
+        if (playedBonus && playedBonus.question && playedBonus.parts && correctTeamName) {
+            for (let j = 0; j < playedBonus.parts.length; j++) {
+                const part = playedBonus.parts[j];
 
                 // To match the current behavior, only set the part if someone scored
                 if (part.controlled_points == 0) {
@@ -477,7 +498,10 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
         // A protest replacement pulls a question out of sequence without consuming the sequential track, so advance
         // by the scheduled index rather than the (possibly end-of-packet) replacement that was actually read.
         previousTossupIndex = protestReplacementIndex != undefined ? scheduledTossupIndex : latestTossupIndex;
-        previousBonusIndex = latestBonusIndex;
+        previousBonusIndex =
+            protestBonusReplacementIndex != undefined && scheduledBonusIndex != undefined
+                ? scheduledBonusIndex
+                : latestBonusIndex;
     }
 
     return {
@@ -686,15 +710,20 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
             }
         }
 
+        // replacement_bonus mirrors replacement_tossup_question: it records a protest replacement, and (like tossups)
+        // only supports a single replacement per cycle, so a cycle with multiple thrown out bonuses keeps the last.
+        let replacementBonusIndex: number | undefined = undefined;
         if (cycle.thrownOutBonuses) {
             for (const thrownOutBonus of cycle.thrownOutBonuses) {
-                // TODO: Unclear on how thrown out bonuses should be handled, since the replacement_bonus is just the
-                // bonus right now. Just add an event for now
                 noteworthyEvents.push(`Bonus thrown out on question ${thrownOutBonus.questionIndex + 1}`);
                 if (thrownOutBonus.replacementQuestionIndex == undefined) {
-                    // Only sequential replacements advance the bonus counter; protest replacements don't shift the
-                    // bonuses later cycles use. See GameState.getBonusIndex.
+                    // Sequential replacement: the next bonus in the packet is used, so advance the running counter.
                     bonusNumber++;
+                } else {
+                    // Protest replacement: pulls a specific bonus and doesn't shift the bonuses later cycles use, so
+                    // leave the running counter alone. It's recorded in replacement_bonus below. See
+                    // GameState.getBonusIndex, which likewise ignores these when computing its sequential offset.
+                    replacementBonusIndex = thrownOutBonus.replacementQuestionIndex;
                 }
             }
         }
@@ -709,8 +738,6 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
                 question_number: tossupNumber,
             },
             replacement_tossup_question: replacementTossup,
-            // TODO: Figure out how to set replacement_bonus. Doesn't really make sense right now, since it seems to be
-            // the same as bonus
             bonus: undefined,
         };
 
@@ -756,15 +783,36 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
                 parts.push(matchPart);
             }
 
-            const matchBonus: IMatchQuestionBonus = {
-                question: {
-                    parts: cycle.bonusAnswer.parts.length,
-                    type: "bonus",
-                    question_number: bonusNumber,
-                },
-                parts,
-            };
-            matchQuestion.bonus = matchBonus;
+            if (replacementBonusIndex != undefined) {
+                // Protest replacement (mirrors replacement_tossup_question): the bonus actually read and answered is
+                // the replacement, so the conversion goes in replacement_bonus, while bonus keeps the scheduled
+                // number as a bare marker with no parts.
+                matchQuestion.replacement_bonus = {
+                    question: {
+                        parts: cycle.bonusAnswer.parts.length,
+                        type: "bonus",
+                        question_number: replacementBonusIndex + 1,
+                    },
+                    parts,
+                };
+                matchQuestion.bonus = {
+                    question: {
+                        parts: cycle.bonusAnswer.parts.length,
+                        type: "bonus",
+                        question_number: bonusNumber,
+                    },
+                    parts: [],
+                };
+            } else {
+                matchQuestion.bonus = {
+                    question: {
+                        parts: cycle.bonusAnswer.parts.length,
+                        type: "bonus",
+                        question_number: bonusNumber,
+                    },
+                    parts,
+                };
+            }
 
             bonusNumber++;
         }

--- a/src/qbj/QBJ.ts
+++ b/src/qbj/QBJ.ts
@@ -318,6 +318,20 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
         let latestBonusIndex: number = previousBonusIndex + 1;
         let latestTossupIndex: number = previousTossupIndex + 1;
 
+        // A protest replacement records the specific question that was actually read (e.g. the last tossup in the
+        // packet) in replacement_tossup_question, while tossup_question keeps the scheduled sequential number. A
+        // sequential (procedural) replacement instead advances both to the same number, so we only treat the
+        // replacement as a protest when the two differ. Sequential throw-outs are still inferred from gaps in the
+        // tossup_question numbers below.
+        const scheduledTossupIndex: number = question.tossup_question.question_number - 1;
+        const protestReplacementIndex: number | undefined =
+            question.replacement_tossup_question != undefined &&
+            question.replacement_tossup_question.question_number !== question.tossup_question.question_number
+                ? question.replacement_tossup_question.question_number - 1
+                : undefined;
+        // The tossup actually read (and buzzed on) is the protest replacement when present, otherwise the scheduled one.
+        const playedTossupIndex: number = protestReplacementIndex ?? scheduledTossupIndex;
+
         // The correct buzz needs to be added after throwing out any tossups, so we have to delay adding it to the cycle
         let addCorrectBuzzEvent: undefined | (() => void);
 
@@ -381,7 +395,7 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
                 buzzMarker.isLastWord = buzz.buzz_position.word_index >= tossupLength - 1;
             }
 
-            const tossupIndex: number = question.tossup_question.question_number - 1;
+            const tossupIndex: number = playedTossupIndex;
             latestTossupIndex = Math.max(tossupIndex, latestTossupIndex);
 
             if (buzz.result.value > 0) {
@@ -416,9 +430,16 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
             };
         }
 
-        for (let j = previousTossupIndex + 1; j < latestTossupIndex; j++) {
-            // We must have thrown out the other questions
-            cycle.addThrownOutTossup(j);
+        if (protestReplacementIndex != undefined) {
+            // The file explicitly recorded a protest replacement: the scheduled tossup was thrown out and a specific
+            // question was read instead. Reconstruct it directly so getTossupIndex returns that question. Protest
+            // replacements don't shift the sequential order, so we don't infer any gap throw-outs here.
+            cycle.addThrownOutTossup(scheduledTossupIndex, protestReplacementIndex);
+        } else {
+            for (let j = previousTossupIndex + 1; j < latestTossupIndex; j++) {
+                // We must have thrown out the other questions
+                cycle.addThrownOutTossup(j);
+            }
         }
 
         if (addCorrectBuzzEvent) {
@@ -453,7 +474,9 @@ export function fromQBJ(qbj: IMatch, packet: PacketState, gameFormat: IGameForma
             }
         }
 
-        previousTossupIndex = latestTossupIndex;
+        // A protest replacement pulls a question out of sequence without consuming the sequential track, so advance
+        // by the scheduled index rather than the (possibly end-of-packet) replacement that was actually read.
+        previousTossupIndex = protestReplacementIndex != undefined ? scheduledTossupIndex : latestTossupIndex;
         previousBonusIndex = latestBonusIndex;
     }
 

--- a/src/qbj/QBJ.ts
+++ b/src/qbj/QBJ.ts
@@ -635,16 +635,31 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
             }
         }
 
+        // replacement_tossup_question only supports a single replacement per cycle (see IMatchQuestion), so a cycle
+        // with multiple thrown out tossups keeps the last one here, while GameState.getTossupIndex uses the first
+        // with a defined replacement. Cycles with multiple replacements are out of scope for now.
         let replacementTossup: IQuestion | undefined = undefined;
         if (cycle.thrownOutTossups) {
             for (const thrownOutTossup of cycle.thrownOutTossups) {
                 noteworthyEvents.push(`Tossup thrown out on question ${thrownOutTossup.questionIndex + 1}`);
-                tossupNumber++;
-                replacementTossup = {
-                    parts: 1,
-                    question_number: tossupNumber,
-                    type: "tossup",
-                };
+                if (thrownOutTossup.replacementQuestionIndex == undefined) {
+                    // Sequential replacement: the next tossup in the packet is used, so advance the running counter.
+                    tossupNumber++;
+                    replacementTossup = {
+                        parts: 1,
+                        question_number: tossupNumber,
+                        type: "tossup",
+                    };
+                } else {
+                    // Protest replacement: pulls a specific question (usually the last in the packet) and doesn't
+                    // shift the questions later cycles use, so leave the running counter alone. GameState
+                    // .getTossupIndex likewise ignores these when computing its sequential offset.
+                    replacementTossup = {
+                        parts: 1,
+                        question_number: thrownOutTossup.replacementQuestionIndex + 1,
+                        type: "tossup",
+                    };
+                }
             }
         }
 
@@ -653,7 +668,11 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
                 // TODO: Unclear on how thrown out bonuses should be handled, since the replacement_bonus is just the
                 // bonus right now. Just add an event for now
                 noteworthyEvents.push(`Bonus thrown out on question ${thrownOutBonus.questionIndex + 1}`);
-                bonusNumber++;
+                if (thrownOutBonus.replacementQuestionIndex == undefined) {
+                    // Only sequential replacements advance the bonus counter; protest replacements don't shift the
+                    // bonuses later cycles use. See GameState.getBonusIndex.
+                    bonusNumber++;
+                }
             }
         }
 

--- a/src/state/Cycle.ts
+++ b/src/state/Cycle.ts
@@ -362,31 +362,33 @@ export class Cycle implements ICycle {
         this.updateIfNeeded();
     }
 
-    public addThrownOutBonus(bonusIndex: number): void {
+    public addThrownOutBonus(bonusIndex: number, replacementQuestionIndex?: number): void {
         if (this.thrownOutBonuses == undefined) {
             this.thrownOutBonuses = [];
         }
 
         this.thrownOutBonuses.push({
             questionIndex: bonusIndex,
+            replacementQuestionIndex,
         });
 
         // Clear the bonus answer event
         if (this.bonusAnswer != undefined) {
             this.resetBonusAnswer();
-            this.bonusAnswer.bonusIndex = bonusIndex + 1;
+            this.bonusAnswer.bonusIndex = replacementQuestionIndex ?? bonusIndex + 1;
         }
 
         this.updateIfNeeded();
     }
 
-    public addThrownOutTossup(tossupIndex: number): void {
+    public addThrownOutTossup(tossupIndex: number, replacementQuestionIndex?: number): void {
         if (this.thrownOutTossups == undefined) {
             this.thrownOutTossups = [];
         }
 
         this.thrownOutTossups.push({
             questionIndex: tossupIndex,
+            replacementQuestionIndex,
         });
 
         // If we threw out the tossup, then we can't have a correct buzz; otherwise the tossup would've been allowed to

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -38,6 +38,9 @@ export class DialogState {
     public messageDialog: IMessageDialogState | undefined;
 
     @ignore
+    public throwOutQuestionDialog: IThrowOutQuestionDialogState | undefined;
+
+    @ignore
     public renamePlayerDialog: RenamePlayerDialogState | undefined;
 
     @ignore
@@ -58,6 +61,7 @@ export class DialogState {
         this.fontDialog = undefined;
         this.importFromQBJDialog = undefined;
         this.messageDialog = undefined;
+        this.throwOutQuestionDialog = undefined;
         this.renamePlayerDialog = undefined;
         this.renameTeamDialog = undefined;
         this.reorderPlayersDialog = undefined;
@@ -108,6 +112,18 @@ export class DialogState {
         if (this.visibleDialog === ModalVisibilityStatus.Message) {
             this.hideModalDialog();
         }
+    }
+
+    public hideThrowOutQuestionDialog(): void {
+        this.throwOutQuestionDialog = undefined;
+        if (this.visibleDialog === ModalVisibilityStatus.ThrowOutQuestion) {
+            this.hideModalDialog();
+        }
+    }
+
+    public showThrowOutQuestionDialog(options: IThrowOutQuestionDialogState): void {
+        this.throwOutQuestionDialog = options;
+        this.visibleDialog = ModalVisibilityStatus.ThrowOutQuestion;
     }
 
     public hideRenamePlayerDialog(): void {
@@ -235,4 +251,15 @@ export class DialogState {
     public showNewGameDialog(): void {
         this.visibleDialog = ModalVisibilityStatus.NewGame;
     }
+}
+
+export interface IThrowOutQuestionDialogState {
+    title: string;
+    message: string;
+    // The pre-computed replacement question number (1-based) shown in the SpinButton. Undefined if the packet
+    // has no available replacement (user must upload more questions first).
+    defaultReplacementNumber: number | undefined;
+    // Upper bound for the SpinButton (total questions of this type in the packet).
+    maxQuestionNumber: number;
+    onConfirm: (replacementIndex: number | undefined) => void;
 }

--- a/src/state/DialogState.ts
+++ b/src/state/DialogState.ts
@@ -12,6 +12,7 @@ import { ModalVisibilityStatus } from "./ModalVisibilityStatus";
 import { RenameTeamDialogState } from "./RenameTeamDialogState";
 import { ImportFromQBJDialogState } from "./ImportFromQBJDialogState";
 import { AddPlayerDialogState } from "./AddPlayerDialogState";
+import { IThrowOutQuestionDialogState } from "./IThrowOutQuestionDialogState";
 import {
     IOKCancelMessageDialogOptions,
     IOKMessageDialogOptions,
@@ -251,15 +252,4 @@ export class DialogState {
     public showNewGameDialog(): void {
         this.visibleDialog = ModalVisibilityStatus.NewGame;
     }
-}
-
-export interface IThrowOutQuestionDialogState {
-    title: string;
-    message: string;
-    // The pre-computed replacement question number (1-based) shown in the SpinButton. Undefined if the packet
-    // has no available replacement (user must upload more questions first).
-    defaultReplacementNumber: number | undefined;
-    // Upper bound for the SpinButton (total questions of this type in the packet).
-    maxQuestionNumber: number;
-    onConfirm: (replacementIndex: number | undefined) => void;
 }

--- a/src/state/Events.ts
+++ b/src/state/Events.ts
@@ -62,6 +62,9 @@ export interface ITimeoutEvent {
 
 export interface IThrowOutQuestionEvent {
     questionIndex: number;
+    // Set for protest replacements, which pull from the end of the packet rather than the next sequential question.
+    // Undefined means the next sequential question is used as the replacement.
+    replacementQuestionIndex?: number;
 }
 
 export type PlayerChangeEvent = IPlayerJoinsEvent | IPlayerLeavesEvent | ISubstitutionEvent;

--- a/src/state/Events.ts
+++ b/src/state/Events.ts
@@ -63,7 +63,8 @@ export interface ITimeoutEvent {
 export interface IThrowOutQuestionEvent {
     questionIndex: number;
     // Set for protest replacements, which pull from the end of the packet rather than the next sequential question.
-    // Undefined means the next sequential question is used as the replacement.
+    // Undefined means the next sequential question is used as the replacement, which preserves the original
+    // behavior from before this property was added.
     replacementQuestionIndex?: number;
 }
 

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -503,13 +503,25 @@ export class GameState {
     }
 
     public getBonusIndex(cycleIndex: number): number {
+        // If this cycle has a protest replacement, return that specific index directly.
+        const currentCycle: Cycle = this.cycles[cycleIndex];
+        const protestReplacement = currentCycle.thrownOutBonuses?.find(
+            (e) => e.replacementQuestionIndex != undefined
+        );
+        if (protestReplacement != undefined) {
+            const idx = protestReplacement.replacementQuestionIndex!;
+            return idx >= this.packet.bonuses.length ? -1 : idx;
+        }
+
         if (this.gameFormat.pairTossupsBonuses) {
-            // Same as the cycle index plus thrown out questions
+            // Same as the cycle index plus sequential (non-protest) thrown-out bonuses
             let thrownOutBonusesCount = 0;
             for (let i = 0; i <= cycleIndex; i++) {
                 const cycle: Cycle = this.cycles[i];
                 if (cycle.thrownOutBonuses !== undefined) {
-                    thrownOutBonusesCount += cycle.thrownOutBonuses.length;
+                    thrownOutBonusesCount += cycle.thrownOutBonuses.filter(
+                        (e) => e.replacementQuestionIndex == undefined
+                    ).length;
                 }
             }
 
@@ -526,7 +538,9 @@ export class GameState {
             }
 
             if (cycle.thrownOutBonuses != undefined) {
-                usedBonusesCount += cycle.thrownOutBonuses.length;
+                usedBonusesCount += cycle.thrownOutBonuses.filter(
+                    (e) => e.replacementQuestionIndex == undefined
+                ).length;
             }
         }
 
@@ -551,11 +565,24 @@ export class GameState {
     }
 
     public getTossupIndex(cycleIndex: number): number {
+        // If this cycle has a protest replacement, return that specific index directly.
+        const currentCycle: Cycle = this.cycles[cycleIndex];
+        const protestReplacement = currentCycle.thrownOutTossups?.find(
+            (e) => e.replacementQuestionIndex != undefined
+        );
+        if (protestReplacement != undefined) {
+            return protestReplacement.replacementQuestionIndex!;
+        }
+
+        // Otherwise, offset by the number of sequential (non-protest) throw-outs up to and including this cycle.
+        // Protest throw-outs don't shift the sequential order for subsequent cycles.
         let thrownOutTossupsCount = 0;
         for (let i = 0; i <= cycleIndex; i++) {
             const cycle: Cycle = this.cycles[i];
             if (cycle.thrownOutTossups !== undefined) {
-                thrownOutTossupsCount += cycle.thrownOutTossups.length;
+                thrownOutTossupsCount += cycle.thrownOutTossups.filter(
+                    (e) => e.replacementQuestionIndex == undefined
+                ).length;
             }
         }
 

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -505,12 +505,11 @@ export class GameState {
     public getBonusIndex(cycleIndex: number): number {
         // If this cycle has a protest replacement, return that specific index directly.
         const currentCycle: Cycle = this.cycles[cycleIndex];
-        const protestReplacement = currentCycle.thrownOutBonuses?.find(
+        const protestReplacementIndex: number | undefined = currentCycle.thrownOutBonuses?.find(
             (e) => e.replacementQuestionIndex != undefined
-        );
-        if (protestReplacement != undefined) {
-            const idx = protestReplacement.replacementQuestionIndex!;
-            return idx >= this.packet.bonuses.length ? -1 : idx;
+        )?.replacementQuestionIndex;
+        if (protestReplacementIndex != undefined) {
+            return protestReplacementIndex >= this.packet.bonuses.length ? -1 : protestReplacementIndex;
         }
 
         if (this.gameFormat.pairTossupsBonuses) {
@@ -567,11 +566,11 @@ export class GameState {
     public getTossupIndex(cycleIndex: number): number {
         // If this cycle has a protest replacement, return that specific index directly.
         const currentCycle: Cycle = this.cycles[cycleIndex];
-        const protestReplacement = currentCycle.thrownOutTossups?.find(
+        const protestReplacementIndex: number | undefined = currentCycle.thrownOutTossups?.find(
             (e) => e.replacementQuestionIndex != undefined
-        );
-        if (protestReplacement != undefined) {
-            return protestReplacement.replacementQuestionIndex!;
+        )?.replacementQuestionIndex;
+        if (protestReplacementIndex != undefined) {
+            return protestReplacementIndex;
         }
 
         // Otherwise, offset by the number of sequential (non-protest) throw-outs up to and including this cycle.

--- a/src/state/GameState.ts
+++ b/src/state/GameState.ts
@@ -564,13 +564,14 @@ export class GameState {
     }
 
     public getTossupIndex(cycleIndex: number): number {
-        // If this cycle has a protest replacement, return that specific index directly.
+        // If this cycle has a protest replacement, return that specific index directly, or -1 if it points past the
+        // packet (e.g. a QBJ loaded with a smaller packet than the game used), matching getBonusIndex.
         const currentCycle: Cycle = this.cycles[cycleIndex];
         const protestReplacementIndex: number | undefined = currentCycle.thrownOutTossups?.find(
             (e) => e.replacementQuestionIndex != undefined
         )?.replacementQuestionIndex;
         if (protestReplacementIndex != undefined) {
-            return protestReplacementIndex;
+            return protestReplacementIndex >= this.packet.tossups.length ? -1 : protestReplacementIndex;
         }
 
         // Otherwise, offset by the number of sequential (non-protest) throw-outs up to and including this cycle.

--- a/src/state/IThrowOutQuestionDialogState.ts
+++ b/src/state/IThrowOutQuestionDialogState.ts
@@ -1,0 +1,10 @@
+export interface IThrowOutQuestionDialogState {
+    title: string;
+    message: string;
+    // The pre-computed replacement question number (1-based) shown in the SpinButton. Undefined if the packet
+    // has no available replacement (user must upload more questions first).
+    defaultReplacementNumber: number | undefined;
+    // Upper bound for the SpinButton (total questions of this type in the packet).
+    maxQuestionNumber: number;
+    onConfirm: (replacementIndex: number | undefined) => void;
+}

--- a/src/state/ModalVisibilityStatus.ts
+++ b/src/state/ModalVisibilityStatus.ts
@@ -16,5 +16,6 @@ export const enum ModalVisibilityStatus {
     RenameTeam,
     ReorderPlayers,
     Scoresheet,
+    ThrowOutQuestion,
     TossupProtest,
 }

--- a/tests/unit/BonusQuestionControllerTests.ts
+++ b/tests/unit/BonusQuestionControllerTests.ts
@@ -32,11 +32,12 @@ describe("BonusQuestionControllerTests", () => {
 
             BonusQuestionController.throwOutBonus(appState, cycle, 0);
 
-            const messageDialog = appState.uiState.dialogState.messageDialog;
-            if (messageDialog == undefined || messageDialog.onOK == undefined) {
-                assert.fail("OK/Cancel dialog should've appeared");
+            const dialog = appState.uiState.dialogState.throwOutQuestionDialog;
+            if (dialog == undefined || dialog.onConfirm == undefined) {
+                assert.fail("Throw out question dialog should've appeared");
             }
-            messageDialog.onOK();
+            // defaultReplacementNumber is 1-based; onConfirm expects a 0-based packet index
+            dialog.onConfirm(dialog.defaultReplacementNumber != undefined ? dialog.defaultReplacementNumber - 1 : undefined);
 
             if (cycle.thrownOutBonuses == undefined) {
                 assert.fail("ThrownOutBonuses was undefined");

--- a/tests/unit/QBJTests.ts
+++ b/tests/unit/QBJTests.ts
@@ -756,6 +756,39 @@ describe("QBJTests", () => {
             }
             expect(roundtripped.value.getTossupIndex(0)).to.equal(3);
         });
+        it("Roundtrip with bonus protest replacement", () => {
+            const game: GameState = new GameState();
+            game.loadPacket(defaultPacket);
+            game.setPlayers(players);
+            game.setGameFormat(GameFormats.ACFGameFormat);
+
+            // Get the tossup so the bonus comes into play, then throw out the bonus and read the last bonus in the
+            // packet (index 3) instead of the sequential one, answering the first part of that replacement.
+            const firstCycle: Cycle = game.cycles[0];
+            firstCycle.addCorrectBuzz(
+                { player: firstTeamPlayers[0], points: 10, position: 1 },
+                0,
+                game.gameFormat,
+                0,
+                3
+            );
+            firstCycle.addThrownOutBonus(0, 3);
+            firstCycle.setBonusPartAnswer(0, firstTeamPlayers[0].teamName, 10);
+
+            // Sanity check: the source game reads back the replacement bonus, not the original
+            expect(game.getBonusIndex(0)).to.equal(3);
+
+            // The full round trip preserves the thrown-out bonus (with its replacement index) and the bonus answer
+            verifyFromQBJRoundtrip(game);
+
+            // Loading the exported QBJ shows the replacement bonus
+            const qbj: IMatch = QBJ.toQBJ(game, "Packet", 1);
+            const roundtripped: IResult<GameState> = QBJ.fromQBJ(qbj, game.packet, game.gameFormat);
+            if (!roundtripped.success) {
+                assert.fail(`Failed to parse the QBJ. Error: '${roundtripped.message}'`);
+            }
+            expect(roundtripped.value.getBonusIndex(0)).to.equal(3);
+        });
     });
     describe("toQBJ", () => {
         it("No buzz game", () => {
@@ -1628,6 +1661,49 @@ describe("QBJTests", () => {
                     expect(match.match_questions.map((q) => q.tossup_question.question_number)).to.deep.equal([
                         1, 2, 3, 4,
                     ]);
+                }
+            );
+        });
+        it("Thrown out bonus with protest replacement", () => {
+            verifyToQBJ(
+                (game) => {
+                    // Protest replacement: get the tossup, then throw out the bonus and read the last bonus in the
+                    // packet (index 3) rather than the sequential one, answering its first part.
+                    game.cycles[0].addCorrectBuzz(
+                        { player: firstTeamPlayers[0], points: 10, position: 1 },
+                        0,
+                        game.gameFormat,
+                        0,
+                        3
+                    );
+                    game.cycles[0].addThrownOutBonus(0, 3);
+                    game.cycles[0].setBonusPartAnswer(0, firstTeamPlayers[0].teamName, 10);
+                },
+                (match) => {
+                    // The answered conversion lives on replacement_bonus (the bonus actually read), pointing at the
+                    // specific bonus that replaced the thrown-out one
+                    const replacementBonus: QBJ.IMatchQuestionBonus | undefined =
+                        match.match_questions[0].replacement_bonus;
+                    if (replacementBonus == undefined || replacementBonus.question == undefined) {
+                        assert.fail("Replacement bonus was undefined");
+                    }
+
+                    expect(replacementBonus.question.question_number).to.equal(4);
+                    expect(replacementBonus.question.type).to.equal("bonus");
+                    expect(replacementBonus.parts[0].controlled_points).to.equal(10);
+
+                    // bonus keeps the scheduled number as a bare marker with no conversion
+                    const scheduledBonus: QBJ.IMatchQuestionBonus | undefined = match.match_questions[0].bonus;
+                    if (scheduledBonus == undefined || scheduledBonus.question == undefined) {
+                        assert.fail("Scheduled bonus was undefined");
+                    }
+                    expect(scheduledBonus.question.question_number).to.equal(1);
+                    expect(scheduledBonus.parts).to.deep.equal([]);
+
+                    // A protest replacement doesn't shift later cycles, so the scheduled bonus numbers stay sequential
+                    expect(
+                        match.match_questions.map((q) => q.bonus?.question?.question_number)
+                    ).to.deep.equal([1, undefined, undefined, undefined]);
                 }
             );
         });

--- a/tests/unit/QBJTests.ts
+++ b/tests/unit/QBJTests.ts
@@ -724,6 +724,38 @@ describe("QBJTests", () => {
 
             verifyFromQBJRoundtrip(game);
         });
+        it("Roundtrip with tossup protest replacement", () => {
+            const game: GameState = new GameState();
+            game.loadPacket(defaultPacket);
+            game.setPlayers(players);
+            game.setGameFormat(GameFormats.ACFGameFormat);
+
+            // Protest replacement: throw out the first tossup and read the last tossup in the packet (index 3)
+            // instead of the next sequential one, then take a correct buzz on that replacement.
+            const firstCycle: Cycle = game.cycles[0];
+            firstCycle.addThrownOutTossup(0, 3);
+            firstCycle.addCorrectBuzz(
+                { player: firstTeamPlayers[0], points: 10, position: 1 },
+                3,
+                game.gameFormat,
+                0,
+                3
+            );
+
+            // Sanity check: the source game reads back the replacement question, not the original
+            expect(game.getTossupIndex(0)).to.equal(3);
+
+            // The full round trip preserves the thrown-out tossup (with its replacement index) and the correct buzz
+            verifyFromQBJRoundtrip(game);
+
+            // Loading the exported QBJ shows the replacement question, not the original or the next sequential one
+            const qbj: IMatch = QBJ.toQBJ(game, "Packet", 1);
+            const roundtripped: IResult<GameState> = QBJ.fromQBJ(qbj, game.packet, game.gameFormat);
+            if (!roundtripped.success) {
+                assert.fail(`Failed to parse the QBJ. Error: '${roundtripped.message}'`);
+            }
+            expect(roundtripped.value.getTossupIndex(0)).to.equal(3);
+        });
     });
     describe("toQBJ", () => {
         it("No buzz game", () => {

--- a/tests/unit/QBJTests.ts
+++ b/tests/unit/QBJTests.ts
@@ -755,6 +755,8 @@ describe("QBJTests", () => {
                 assert.fail(`Failed to parse the QBJ. Error: '${roundtripped.message}'`);
             }
             expect(roundtripped.value.getTossupIndex(0)).to.equal(3);
+            // The protest replacement doesn't shift later cycles: the next cycle still reads its sequential tossup
+            expect(roundtripped.value.getTossupIndex(1)).to.equal(1);
         });
         it("Roundtrip with bonus protest replacement", () => {
             const game: GameState = new GameState();
@@ -788,6 +790,8 @@ describe("QBJTests", () => {
                 assert.fail(`Failed to parse the QBJ. Error: '${roundtripped.message}'`);
             }
             expect(roundtripped.value.getBonusIndex(0)).to.equal(3);
+            // The protest replacement doesn't shift later cycles: the next cycle still reads its sequential bonus
+            expect(roundtripped.value.getBonusIndex(1)).to.equal(1);
         });
     });
     describe("toQBJ", () => {

--- a/tests/unit/QBJTests.ts
+++ b/tests/unit/QBJTests.ts
@@ -1561,6 +1561,44 @@ describe("QBJTests", () => {
                 }
             );
         });
+        it("Thrown out tossup with protest replacement", () => {
+            verifyToQBJ(
+                (game) => {
+                    // Protest replacement: throw out the first tossup and replace it with the last tossup in the
+                    // packet (index 3) rather than the next sequential one.
+                    game.cycles[0].addThrownOutTossup(0, 3);
+                    game.cycles[0].addCorrectBuzz(
+                        {
+                            player: firstTeamPlayers[0],
+                            points: 10,
+                            position: 1,
+                            isLastWord: true,
+                        },
+                        3,
+                        game.gameFormat,
+                        0,
+                        3
+                    );
+                },
+                (match) => {
+                    const replacementTossup: QBJ.IQuestion | undefined =
+                        match.match_questions[0].replacement_tossup_question;
+                    if (replacementTossup == undefined) {
+                        assert.fail("Replacement tossup was undefined");
+                    }
+
+                    // The replacement points at the specific question that was read, not the next sequential one
+                    expect(replacementTossup.question_number).to.equal(4);
+                    expect(replacementTossup.type).to.equal("tossup");
+
+                    // A protest replacement doesn't shift the questions used by later cycles, so the tossup numbers
+                    // stay on the sequential track instead of drifting by one
+                    expect(match.match_questions.map((q) => q.tossup_question.question_number)).to.deep.equal([
+                        1, 2, 3, 4,
+                    ]);
+                }
+            );
+        });
         it("Thrown out bonus", () => {
             verifyToQBJ(
                 (game) => {

--- a/tests/unit/ThrowOutQuestionMessageTests.ts
+++ b/tests/unit/ThrowOutQuestionMessageTests.ts
@@ -102,6 +102,23 @@ describe("ThrowOutQuestionMessageTests", () => {
             expect(message).to.not.contain("tiebreaker");
         });
 
+        it("Tiebreaker: a sudden-death tossup past the fixed overtime block is a tiebreaker", () => {
+            // regulationTossupCount 1 plus a fixed 2-question overtime block => cycles 1 and 2 are the block and
+            // cycle 3 is sudden death, so it's a tiebreaker even though the format isn't sudden death from the start.
+            const format: IGameFormat = {
+                ...GameFormats.ACFGameFormat,
+                regulationTossupCount: 1,
+                minimumOvertimeQuestionCount: 2,
+            };
+            const appState: AppState = createAppState(format);
+
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 3, "tossup", 4);
+
+            expect(message).to.contain("tiebreaker tossup");
+            // Question 4 is the last in the packet, so there's nothing sequential to replace it with
+            expect(replacementIndex).to.equal(undefined);
+        });
+
         it("No replacement available when the packet has no more questions", () => {
             const appState: AppState = createAppState();
 

--- a/tests/unit/ThrowOutQuestionMessageTests.ts
+++ b/tests/unit/ThrowOutQuestionMessageTests.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+
+import * as GameFormats from "src/state/GameFormats";
+import { AppState } from "src/state/AppState";
+import { Bonus, PacketState, Tossup } from "src/state/PacketState";
+import { Player } from "src/state/TeamState";
+import { IGameFormat } from "src/state/IGameFormat";
+import { getThrowOutQuestionPrompt } from "src/components/ThrowOutQuestionMessage";
+
+const players: Player[] = [
+    new Player("Alice", "A", /* isStarter */ true),
+    new Player("Bob", "B", /* isStarter */ true),
+];
+
+function createPacket(): PacketState {
+    const packet: PacketState = new PacketState();
+    packet.setTossups([
+        new Tossup("first q", "first a"),
+        new Tossup("second q", "second a"),
+        new Tossup("third q", "third a"),
+        new Tossup("fourth q", "fourth a"),
+    ]);
+    packet.setBonuses([
+        new Bonus("first leadin", [{ question: "first q", answer: "first a", value: 10 }]),
+        new Bonus("second leadin", [{ question: "second q", answer: "second a", value: 10 }]),
+        new Bonus("third leadin", [{ question: "third q", answer: "third a", value: 10 }]),
+        new Bonus("fourth leadin", [{ question: "fourth q", answer: "fourth a", value: 10 }]),
+    ]);
+    return packet;
+}
+
+function createAppState(gameFormat?: IGameFormat): AppState {
+    const appState: AppState = new AppState();
+    appState.game.addNewPlayers(players);
+    appState.game.loadPacket(createPacket());
+    if (gameFormat != undefined) {
+        appState.game.setGameFormat(gameFormat);
+    }
+
+    return appState;
+}
+
+describe("ThrowOutQuestionMessageTests", () => {
+    describe("getThrowOutQuestionPrompt", () => {
+        it("Procedural: mid-game with no events afterward replaces with the next question", () => {
+            const appState: AppState = createAppState();
+
+            // Throw out tossup 1 (cycle 0) with nothing recorded afterward => moderator procedural error.
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 0, "tossup", 1);
+
+            expect(replacementIndex).to.equal(1); // next sequential tossup (0-based)
+            expect(message).to.contain("procedural error");
+            expect(message).to.contain("replaced with tossup 2");
+        });
+
+        it("Protest: mid-game with events afterward replaces with the last question in the packet", () => {
+            const appState: AppState = createAppState();
+
+            // Record a buzz in a later cycle so there is game data after cycle 0 => protest resolution.
+            appState.game.cycles[1].addWrongBuzz(
+                { player: players[0], points: -5, position: 0 },
+                1,
+                appState.game.gameFormat
+            );
+
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 0, "tossup", 1);
+
+            expect(replacementIndex).to.equal(3); // last tossup in the 4-question packet (0-based)
+            expect(message).to.contain("protest resolution");
+            expect(message).to.contain("replaced with tossup 4");
+        });
+
+        it("Tiebreaker: an overtime tossup in a sudden-death format is a tiebreaker", () => {
+            // regulationTossupCount 2 => cycle index 2 is the first overtime tossup; sudden death (1 OT question).
+            const format: IGameFormat = {
+                ...GameFormats.ACFGameFormat,
+                regulationTossupCount: 2,
+                minimumOvertimeQuestionCount: 1,
+            };
+            const appState: AppState = createAppState(format);
+
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 2, "tossup", 3);
+
+            expect(replacementIndex).to.equal(3); // next sequential tossup (0-based)
+            expect(message).to.contain("tiebreaker tossup");
+            expect(message).to.contain("replaced with tossup 4");
+        });
+
+        it("Tiebreaker only applies in sudden-death formats, not fixed-block overtime", () => {
+            // Same overtime cycle, but a fixed 3-question overtime block is not sudden death, so it falls through.
+            const format: IGameFormat = {
+                ...GameFormats.ACFGameFormat,
+                regulationTossupCount: 2,
+                minimumOvertimeQuestionCount: 3,
+            };
+            const appState: AppState = createAppState(format);
+
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 2, "tossup", 3);
+
+            expect(replacementIndex).to.equal(3);
+            expect(message).to.contain("procedural error");
+            expect(message).to.not.contain("tiebreaker");
+        });
+
+        it("No replacement available when the packet has no more questions", () => {
+            const appState: AppState = createAppState();
+
+            // Throw out the last tossup (question 4); there is no next question to replace it with.
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 3, "tossup", 4);
+
+            expect(replacementIndex).to.equal(undefined);
+            expect(message).to.contain("Additional questions need to be uploaded");
+        });
+
+        it("Bonus throw-out uses the bonus wording and is never a tiebreaker", () => {
+            const appState: AppState = createAppState();
+
+            const { message, replacementIndex } = getThrowOutQuestionPrompt(appState, 0, "bonus", 1);
+
+            expect(replacementIndex).to.equal(1);
+            expect(message).to.contain("replaced with bonus 2");
+        });
+    });
+});

--- a/tests/unit/TossupQuestionControllerTests.ts
+++ b/tests/unit/TossupQuestionControllerTests.ts
@@ -23,11 +23,12 @@ describe("TossupQuestionControllerTests", () => {
 
             TossupQuestionController.throwOutTossup(appState, cycle, 1);
 
-            const messageDialog = appState.uiState.dialogState.messageDialog;
-            if (messageDialog == undefined || messageDialog.onOK == undefined) {
-                assert.fail("OK/Cancel dialog should've appeared");
+            const dialog = appState.uiState.dialogState.throwOutQuestionDialog;
+            if (dialog == undefined || dialog.onConfirm == undefined) {
+                assert.fail("Throw out question dialog should've appeared");
             }
-            messageDialog.onOK();
+            // defaultReplacementNumber is 1-based; onConfirm expects a 0-based packet index
+            dialog.onConfirm(dialog.defaultReplacementNumber != undefined ? dialog.defaultReplacementNumber - 1 : undefined);
 
             if (cycle.thrownOutTossups == undefined) {
                 assert.fail("ThrownOutTossups was undefined");


### PR DESCRIPTION
- Detect tiebreaker, protest, and procedural scenarios to identify replacement question index
- Protest replacements pull from end of packet and don't shift subsequent question ordering
- Moderator can expand a collapsible input to override the auto-selected replacement before confirming