### PR TITLE
Add AppState.activeGame to replace external use of AppState.game

### DIFF
--- a/src/components/Answer.tsx
+++ b/src/components/Answer.tsx
@@ -10,7 +10,7 @@ import { AppState } from "../state/AppState";
 export const Answer = observer(function Answer(props: IAnswerProps): JSX.Element {
     const appState: AppState = useAppState();
     const formattedText: IFormattedText[] = FormattedTextParser.parseFormattedText(props.text.trimLeft(), {
-        pronunciationGuideMarkers: appState.game.gameFormat.pronunciationGuideMarkers,
+        pronunciationGuideMarkers: appState.activeGame.gameFormat.pronunciationGuideMarkers,
     });
 
     return (

--- a/src/components/BonusQuestion.tsx
+++ b/src/components/BonusQuestion.tsx
@@ -31,8 +31,8 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
     };
     const formattedLeadin: IFormattedText[] = React.useMemo(
         () =>
-            PacketState.getBonusWords(`${props.bonusIndex + 1}. ${props.bonus.leadin}`, props.appState.game.gameFormat),
-        [props.bonusIndex, props.bonus.leadin, props.appState.game.gameFormat]
+            PacketState.getBonusWords(`${props.bonusIndex + 1}. ${props.bonus.leadin}`, props.appState.activeGame.gameFormat),
+        [props.bonusIndex, props.bonus.leadin, props.appState.activeGame.gameFormat]
     );
     const [lastBonus, setLastBonus] = React.useState(props.bonus);
 
@@ -69,7 +69,7 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
     const disabled = !props.inPlay;
     const disableThrowOutButton: boolean =
         disabled ||
-        props.appState.game.cycles.some(
+        props.appState.activeGame.cycles.some(
             (cycle) => cycle.bonusAnswer != undefined && cycle.bonusAnswer.bonusIndex > props.bonusIndex
         );
     const throwOutButtonTooltip: string =
@@ -81,9 +81,9 @@ export const BonusQuestion = observer(function BonusQuestion(props: IBonusQuesti
                 key={index}
                 bonusPart={bonusPartProps}
                 cycle={props.cycle}
-                gameFormat={props.appState.game.gameFormat}
+                gameFormat={props.appState.activeGame.gameFormat}
                 partNumber={index + 1}
-                teamNames={props.appState.game.teamNames}
+                teamNames={props.appState.activeGame.teamNames}
                 disabled={disabled}
             />
         );

--- a/src/components/BuzzMenu.tsx
+++ b/src/components/BuzzMenu.tsx
@@ -23,7 +23,7 @@ import { Theme, ThemeContext } from "@fluentui/react";
 export const BuzzMenu = observer(function BuzzMenu(props: IBuzzMenuProps) {
     const onHideBuzzMenu: () => void = React.useCallback(() => onBuzzMenuDismissed(props), [props]);
 
-    const teamNames: string[] = props.appState.game.teamNames;
+    const teamNames: string[] = props.appState.activeGame.teamNames;
     const menuItems: IContextualMenuItem[] = [];
 
     return (
@@ -61,7 +61,7 @@ function getPlayerMenuItems(props: IBuzzMenuProps, theme: Theme | undefined, tea
     // TODO: Need to support Wrong (1st buzz) and Wrong (2nd buzz)
     // TODO: Add some highlighting/indicator on the player to show that they have a buzz in a different word
 
-    const players: Set<Player> = props.appState.game.getActivePlayers(teamName, props.appState.uiState.cycleIndex);
+    const players: Set<Player> = props.appState.activeGame.getActivePlayers(teamName, props.appState.uiState.cycleIndex);
     const menuItems: IContextualMenuItem[] = [];
 
     let index = 0;
@@ -173,25 +173,25 @@ function onCorrectClicked(
         // Don't include a bonus index if there should be no bonus for this correct buzz
         // TODO: This is an example of logic that should be moved out of the view layer
         const bonusIndex: number | undefined =
-            props.appState.game.gameFormat.overtimeIncludesBonuses ||
-            props.appState.uiState.cycleIndex < props.appState.game.gameFormat.regulationTossupCount
+            props.appState.activeGame.gameFormat.overtimeIncludesBonuses ||
+            props.appState.uiState.cycleIndex < props.appState.activeGame.gameFormat.regulationTossupCount
                 ? props.bonusIndex
                 : undefined;
 
         // If we don't know the number of parts, assume it's 3, which is standard
         const partsCount: number | undefined =
-            bonusIndex != undefined && props.appState.game.packet.bonuses[bonusIndex] != undefined
-                ? props.appState.game.packet.bonuses[bonusIndex].parts.length
+            bonusIndex != undefined && props.appState.activeGame.packet.bonuses[bonusIndex] != undefined
+                ? props.appState.activeGame.packet.bonuses[bonusIndex].parts.length
                 : 3;
 
         props.cycle.addCorrectBuzz(
             {
                 player,
                 position: item.data.props.wordIndex,
-                points: props.tossup.getPointsAtPosition(props.appState.game.gameFormat, item.data.props.wordIndex),
+                points: props.tossup.getPointsAtPosition(props.appState.activeGame.gameFormat, item.data.props.wordIndex),
             },
             props.tossupNumber - 1,
-            props.appState.game.gameFormat,
+            props.appState.activeGame.gameFormat,
             bonusIndex,
             partsCount
         );
@@ -210,7 +210,7 @@ function onWrongClicked(
     const { props, player } = { ...item.data };
 
     if (item.checked) {
-        props.cycle.removeWrongBuzz(player, props.appState.game.gameFormat);
+        props.cycle.removeWrongBuzz(player, props.appState.activeGame.gameFormat);
     } else if (item.checked === false) {
         const marker: IBuzzMarker = {
             isLastWord: props.isLastWord,
@@ -222,7 +222,7 @@ function onWrongClicked(
         // If we're at the end of the question, or if there's already been a neg from a different team, then make it a
         // no penalty buzz
         const pointsAtPosition: number = props.tossup.getPointsAtPosition(
-            props.appState.game.gameFormat,
+            props.appState.activeGame.gameFormat,
             props.wordIndex,
             false
         );
@@ -235,7 +235,7 @@ function onWrongClicked(
             }
         }
 
-        props.cycle.addWrongBuzz(marker, props.tossupNumber - 1, props.appState.game.gameFormat);
+        props.cycle.addWrongBuzz(marker, props.tossupNumber - 1, props.appState.activeGame.gameFormat);
     }
 }
 

--- a/src/components/CycleChooser.tsx
+++ b/src/components/CycleChooser.tsx
@@ -137,7 +137,7 @@ export const CycleChooser = observer(function CycleChooser() {
 
 function shouldNextButtonExport(appState: AppState): boolean {
     const nextCycleIndex: number = appState.uiState.cycleIndex + 1;
-    return nextCycleIndex >= appState.game.playableCycles.length;
+    return nextCycleIndex >= appState.activeGame.playableCycles.length;
 }
 
 function onProposedQuestionNumberBlur(event: React.FocusEvent<HTMLInputElement>, appState: AppState): void {
@@ -180,7 +180,7 @@ function commitCycleIndex(appState: AppState, value: string): void {
     }
 
     const propsedCycleIndex: number = parseInt(value, 10);
-    if (propsedCycleIndex >= 1 && propsedCycleIndex <= appState.game.packet.tossups.length) {
+    if (propsedCycleIndex >= 1 && propsedCycleIndex <= appState.activeGame.packet.tossups.length) {
         appState.uiState.setCycleIndex(propsedCycleIndex - 1);
     }
 

--- a/src/components/EventViewer.tsx
+++ b/src/components/EventViewer.tsx
@@ -65,7 +65,7 @@ export const EventViewer = observer(function EventViewer(): JSX.Element | null {
             // TODO: Consider adding autoruns for scores/finalScore so we don't have to consider what context it's run
             // in. Just swapping scores with a scores2 value set during autorun didn't work initially, so it needs more
             // investigation.
-            data: appState.game.scores.slice(0, appState.game.playableCycles.length),
+            data: appState.activeGame.scores.slice(0, appState.activeGame.playableCycles.length),
         },
     ];
 
@@ -81,7 +81,7 @@ export const EventViewer = observer(function EventViewer(): JSX.Element | null {
         getSelectedIndices: () => [appState.uiState.cycleIndex],
         getSelectedCount: () => 1,
         isRangeSelected: (): boolean => false,
-        isAllSelected: () => appState.uiState.cycleIndex === appState.game.playableCycles.length,
+        isAllSelected: () => appState.uiState.cycleIndex === appState.activeGame.playableCycles.length,
         isIndexSelected: (index) => index === appState.uiState.cycleIndex,
         isKeySelected: () => false,
         setAllSelected: dummyFunction,
@@ -126,7 +126,7 @@ export const EventViewer = observer(function EventViewer(): JSX.Element | null {
                 checkboxVisibility={CheckboxVisibility.hidden}
                 selectionMode={SelectionMode.single}
                 columns={columns}
-                items={appState.game.playableCycles}
+                items={appState.activeGame.playableCycles}
                 onActiveItemChanged={activeItemChangedHandler}
                 onRenderItemColumn={renderColumnHandler}
                 selection={selection}
@@ -157,7 +157,7 @@ function onRenderItemColumn(item: Cycle, appState: AppState, index: number, colu
 
             return (
                 <>
-                    <CycleItemList cycle={item} game={appState.game} />
+                    <CycleItemList cycle={item} game={appState.activeGame} />
                     <Text>{`(${scoreInCurrentCycle.join(" - ")})`}</Text>
                 </>
             );

--- a/src/components/GameBar.tsx
+++ b/src/components/GameBar.tsx
@@ -27,7 +27,7 @@ export const GameBar = observer(function GameBar(): JSX.Element {
     // This should pop up the new game handler
     const appState: AppState = useAppState();
     const uiState: UIState = appState.uiState;
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
 
     const newGameHandler = React.useCallback(() => {
         if (appState.game.hasUpdates) {
@@ -234,7 +234,7 @@ function getActionSubMenuItems(
 ): ICommandBarItemProps[] {
     const items: ICommandBarItemProps[] = [];
     const uiState: UIState = appState.uiState;
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
 
     const playerManagementSection: ICommandBarItemProps = getPlayerManagementSubMenuItems(
         appState,
@@ -263,10 +263,10 @@ function getActionSubMenuItems(
                     onClick: () =>
                         TossupQuestionController.throwOutTossup(
                             appState,
-                            appState.game.cycles[appState.uiState.cycleIndex],
-                            appState.game.getTossupIndex(appState.uiState.cycleIndex) + 1
+                            appState.activeGame.cycles[appState.uiState.cycleIndex],
+                            appState.activeGame.getTossupIndex(appState.uiState.cycleIndex) + 1
                         ),
-                    disabled: appState.game.cycles.length === 0,
+                    disabled: appState.activeGame.cycles.length === 0,
                 },
                 {
                     key: "removeBonus",
@@ -274,10 +274,10 @@ function getActionSubMenuItems(
                     onClick: () =>
                         BonusQuestionController.throwOutBonus(
                             appState,
-                            appState.game.cycles[appState.uiState.cycleIndex],
-                            appState.game.getBonusIndex(appState.uiState.cycleIndex)
+                            appState.activeGame.cycles[appState.uiState.cycleIndex],
+                            appState.activeGame.getBonusIndex(appState.uiState.cycleIndex)
                         ),
-                    disabled: appState.game.cycles.length === 0,
+                    disabled: appState.activeGame.cycles.length === 0,
                 },
             ],
         },
@@ -295,7 +295,7 @@ function getActionSubMenuItems(
                     key: "addMoreQuestions",
                     text: "Add questions...",
                     onClick: addQuestionsHandler,
-                    disabled: appState.game.cycles.length === 0,
+                    disabled: appState.activeGame.cycles.length === 0,
                 },
             ],
         },
@@ -434,7 +434,7 @@ function getViewSubMenuItems(appState: AppState): ICommandBarItemProps[] {
         {
             key: "scoresheet",
             text: "Scoresheet...",
-            disabled: appState.game.cycles.length === 0,
+            disabled: appState.activeGame.cycles.length === 0,
             onClick: () => {
                 appState.uiState.dialogState.showScoresheetDialog();
             },
@@ -563,7 +563,7 @@ function getPlayerManagementSubMenuItems(
     //       existing action (sub vs join)
     //     - Should there be a color code for active players?
 
-    const gameMenuItemsDisabled: boolean = appState.game.cycles.length === 0;
+    const gameMenuItemsDisabled: boolean = appState.activeGame.cycles.length === 0;
 
     const addPlayerItem: ICommandBarItemProps = {
         key: "addNewPlayer",
@@ -796,7 +796,7 @@ function onPlayerEnterClick(
     }
 
     const appState: AppState = item.data.appState;
-    appState.game.addInactivePlayer(item.data.activePlayer, appState.uiState.cycleIndex);
+    appState.activeGame.addInactivePlayer(item.data.activePlayer, appState.uiState.cycleIndex);
 }
 
 function onProtestTossupClick(
@@ -809,7 +809,7 @@ function onProtestTossupClick(
         return;
     }
 
-    const { game, uiState } = item.data.appState;
+    const { activeGame: game, uiState } = item.data.appState;
 
     const cycle: Cycle = game.cycles[uiState.cycleIndex];
     if (cycle?.orderedBuzzes == undefined) {
@@ -835,7 +835,7 @@ function onProtestTossupClick(
 }
 
 function buildCopyTossupProtestInfoText(appState: AppState, cycle: Cycle, protest: ITossupProtestEvent): string {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const uiState: UIState = appState.uiState;
     const packetName: string = uiState.packetFilename != undefined ? `"${uiState.packetFilename}"` : "";
 
@@ -860,7 +860,7 @@ function buildCopyTossupProtestInfoText(appState: AppState, cycle: Cycle, protes
 }
 
 function buildCopyBonusProtestInfoText(appState: AppState, cycle: Cycle, protest: IBonusProtestEvent): string {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const uiState: UIState = appState.uiState;
     const packetName: string = uiState.packetFilename != undefined ? `"${uiState.packetFilename}"` : "";
     const bonus: Bonus = game.packet.bonuses[protest.questionIndex];
@@ -921,7 +921,7 @@ function onPlayerLeaveClick(
         message: `Are you sure you want to let the player "${item.data.activePlayer.name}" from team "${
             item.data.activePlayer.teamName
         }" leave the game before question #${appState.uiState.cycleIndex + 1}?`,
-        onOK: () => appState.game.cycles[appState.uiState.cycleIndex].addPlayerLeaves(item.data.activePlayer),
+        onOK: () => appState.activeGame.cycles[appState.uiState.cycleIndex].addPlayerLeaves(item.data.activePlayer),
     });
 }
 
@@ -949,7 +949,7 @@ function onSwapPlayerClick(
         return;
     }
 
-    const { uiState, game } = item.data.appState;
+    const { uiState, activeGame: game } = item.data.appState;
     const cycleIndex: number = uiState.cycleIndex;
     const halftimeIndex: number = Math.floor(game.gameFormat.regulationTossupCount / 2);
 

--- a/src/components/GameViewer.tsx
+++ b/src/components/GameViewer.tsx
@@ -16,7 +16,7 @@ const scoreboardAndQuestionViewerTokens: IStackTokens = { childrenGap: 20 };
 
 export const GameViewer = observer(function GameViewer() {
     const appState: AppState = useAppState();
-    const gameExists: boolean = appState.game.isLoaded;
+    const gameExists: boolean = appState.activeGame.isLoaded;
 
     const classes: IGameViewerClassNames = getClassNames(
         gameExists,

--- a/src/components/ModaqControl.tsx
+++ b/src/components/ModaqControl.tsx
@@ -264,10 +264,10 @@ function shortcutHandler(event: KeyboardEvent, appState: AppState): void {
     switch (event.key.toUpperCase()) {
         case "E":
             // Go to the end of a tossup and open up the buzz menu.
-            const tossup: Tossup | undefined = appState.game.getTossup(appState.uiState.cycleIndex);
+            const tossup: Tossup | undefined = appState.activeGame.getTossup(appState.uiState.cycleIndex);
             if (tossup) {
                 // Issue is that this removes parens, so we don't have all the info we need
-                const words: ITossupWord[] = tossup.getWords(appState.game.gameFormat);
+                const words: ITossupWord[] = tossup.getWords(appState.activeGame.gameFormat);
                 const index: number = words.filter((word) => word.canBuzzOn).length - 1;
 
                 appState.uiState.setSelectedWordIndex(index);
@@ -290,7 +290,7 @@ function shortcutHandler(event: KeyboardEvent, appState: AppState): void {
             break;
 
         case "N":
-            if (appState.uiState.cycleIndex + 1 < appState.game.playableCycles.length) {
+            if (appState.uiState.cycleIndex + 1 < appState.activeGame.playableCycles.length) {
                 appState.uiState.nextCycle();
             }
             event.preventDefault();
@@ -313,7 +313,7 @@ function shortcutHandler(event: KeyboardEvent, appState: AppState): void {
             // This shortcut is only supported when bouncebacks are disabled. We could add support for it later and just
             // toggle through all the fields, but the logic is slightly more complicated and very few formats use
             // bouncebacks.
-            if (appState.game.gameFormat.bonusesBounceBack) {
+            if (appState.activeGame.gameFormat.bonusesBounceBack) {
                 event.preventDefault();
                 event.stopPropagation();
 
@@ -323,8 +323,8 @@ function shortcutHandler(event: KeyboardEvent, appState: AppState): void {
             // If there are bonuses and they are active, toggle the bonus part. We have to do some defensive checks to
             // make sure that we can update the bonus
             const cycleIndex: number = appState.uiState.cycleIndex;
-            const cycle: Cycle = appState.game.cycles[cycleIndex];
-            const bonus: Bonus | undefined = appState.game.getBonus(cycleIndex);
+            const cycle: Cycle = appState.activeGame.cycles[cycleIndex];
+            const bonus: Bonus | undefined = appState.activeGame.getBonus(cycleIndex);
             if (cycle.correctBuzz == undefined || bonus == undefined) {
                 event.preventDefault();
                 event.stopPropagation();

--- a/src/components/PacketLoader.tsx
+++ b/src/components/PacketLoader.tsx
@@ -151,7 +151,7 @@ function loadJsonPacket(props: IPacketLoaderProps, json: string): void {
 
     const existingPacketName: string | undefined = props.updateFilename
         ? uiState.packetFilename
-        : props.appState.game.packet.name;
+        : props.appState.activeGame.packet.name;
     const packet: PacketState | undefined = PacketLoaderController.loadPacket(
         props.appState,
         parsedPacket,

--- a/src/components/PacketNameLabel.tsx
+++ b/src/components/PacketNameLabel.tsx
@@ -8,9 +8,9 @@ import { useAppState } from "../contexts/StateContext";
 export const PacketNameLabel = observer(function PacketNameLabel() {
     const appState: AppState = useAppState();
 
-    if (!(appState.game.packet.name || appState.uiState.packetFilename)) {
+    if (!(appState.activeGame.packet.name || appState.uiState.packetFilename)) {
         return <></>;
     }
 
-    return <Text>Packet: {appState.game.packet.name ?? appState.uiState.packetFilename}</Text>;
+    return <Text>Packet: {appState.activeGame.packet.name ?? appState.uiState.packetFilename}</Text>;
 });

--- a/src/components/QuestionViewer.tsx
+++ b/src/components/QuestionViewer.tsx
@@ -29,7 +29,7 @@ export const QuestionViewer = observer(function QuestionViewer() {
     const fontSize: number = appState.uiState.questionFontSize;
     const fontFamily: string = appState.uiState.fontFamily;
     const classes: IQuestionViewerClassNames = getClassNames(appState.uiState.questionFontColor, fontSize);
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const uiState: UIState = appState.uiState;
 
     const cycle: Cycle = game.playableCycles[uiState.cycleIndex];

--- a/src/components/QuestionViewerContainer.tsx
+++ b/src/components/QuestionViewerContainer.tsx
@@ -11,7 +11,7 @@ export const QuestionViewerContainer = observer(function QuestionViewerContainer
     const appState: AppState = useAppState();
     const classes: IQuestionViewerContainerClassNames = getClassNames();
 
-    if (!appState.game.isLoaded) {
+    if (!appState.activeGame.isLoaded) {
         return null;
     }
 

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -19,8 +19,8 @@ export const Scoreboard = observer(function Scoreboard() {
     const appState: AppState = useAppState();
     const classes: IScoreboardStyle = getClassNames();
 
-    const scores: number[] = appState.game.finalScore;
-    const teamNames = appState.game.teamNames;
+    const scores: number[] = appState.activeGame.finalScore;
+    const teamNames = appState.activeGame.teamNames;
     let label: JSX.Element | undefined;
     if (appState.uiState.isScoreVertical) {
         label = (
@@ -65,7 +65,7 @@ export const Scoreboard = observer(function Scoreboard() {
 const ProtestIndicator = observer(function ProtestIndicator() {
     const appState: AppState = useAppState();
 
-    return appState.game.protestsMatter ? (
+    return appState.activeGame.protestsMatter ? (
         <Stack horizontal={true}>
             <StackItem>
                 <Icon iconName="Warning" styles={warningIconStyles} />

--- a/src/components/TossupQuestion.tsx
+++ b/src/components/TossupQuestion.tsx
@@ -30,7 +30,7 @@ export const TossupQuestion = observer(function TossupQuestion(props: IQuestionP
         }
     }
 
-    const disableThrowOutButton: boolean = props.appState.game.cycles.some(
+    const disableThrowOutButton: boolean = props.appState.activeGame.cycles.some(
         (cycle) => cycle.orderedBuzzes.length > 0 && cycle.orderedBuzzes[0].tossupIndex + 1 > props.tossupNumber
     );
     const throwOutButtonTooltip: string = disableThrowOutButton
@@ -42,7 +42,7 @@ export const TossupQuestion = observer(function TossupQuestion(props: IQuestionP
         .filter((buzz) => buzz.tossupIndex === props.tossupNumber - 1)
         .map((buzz) => buzz.marker.position);
 
-    const words: ITossupWord[] = props.tossup.getWords(props.appState.game.gameFormat);
+    const words: ITossupWord[] = props.tossup.getWords(props.appState.activeGame.gameFormat);
 
     let questionWords: JSX.Element[] = [<span key="tuNumber">{props.tossupNumber}. </span>];
 

--- a/src/components/dialogs/AddPlayerDialog.tsx
+++ b/src/components/dialogs/AddPlayerDialog.tsx
@@ -60,7 +60,7 @@ const AddPlayerDialogBody = observer(function AddPlayerDialogBody(props: IAddPla
 
     const newPlayer: IPlayer = addPlayerDialogState.player;
 
-    const teamOptions: IDropdownOption[] = appState.game.teamNames.map((teamName, index) => {
+    const teamOptions: IDropdownOption[] = appState.activeGame.teamNames.map((teamName, index) => {
         return {
             key: index,
             text: teamName,

--- a/src/components/dialogs/AddPlayerDialogController.ts
+++ b/src/components/dialogs/AddPlayerDialogController.ts
@@ -6,7 +6,7 @@ import { UIState } from "../../state/UIState";
 import { AddPlayerDialogState } from "../../state/AddPlayerDialogState";
 
 export function addPlayer(appState: AppState): void {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const uiState: UIState = appState.uiState;
 
     if (validatePlayer(appState) != undefined) {
@@ -53,11 +53,11 @@ export function validatePlayer(appState: AppState): string | undefined {
         return "Player name cannot be blank";
     }
 
-    if (appState.game.teamNames.indexOf(newPlayer.teamName) === -1) {
+    if (appState.activeGame.teamNames.indexOf(newPlayer.teamName) === -1) {
         return "Team doesn't exist";
     }
 
-    const playersOnTeam: Player[] = [...appState.game.getPlayers(newPlayer.teamName), newPlayer];
+    const playersOnTeam: Player[] = [...appState.activeGame.getPlayers(newPlayer.teamName), newPlayer];
     return NewGameValidator.newPlayerNameUnique(playersOnTeam, trimmedPlayerName);
 }
 

--- a/src/components/dialogs/AddQuestionsDialogController.ts
+++ b/src/components/dialogs/AddQuestionsDialogController.ts
@@ -8,7 +8,7 @@ export function loadPacket(appState: AppState, packet: PacketState): void {
 }
 
 export function commit(appState: AppState): void {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const state: AddQuestionDialogState | undefined = appState.uiState.dialogState.addQuestions;
     if (state == undefined) {
         throw new Error("Tried adding more questions without any questions");

--- a/src/components/dialogs/BonusProtestDialogController.ts
+++ b/src/components/dialogs/BonusProtestDialogController.ts
@@ -17,7 +17,7 @@ export function commit(appState: AppState, cycle: Cycle): void {
         teamName =
             part == undefined || (part.points <= 0 && (part.teamName === bonusTeamName || part.teamName === ""))
                 ? bonusTeamName
-                : appState.game.teamNames.find((name) => name !== bonusTeamName) ?? "";
+                : appState.activeGame.teamNames.find((name) => name !== bonusTeamName) ?? "";
     }
 
     if (pendingProtestEvent) {

--- a/src/components/dialogs/RenamePlayerDialogController.ts
+++ b/src/components/dialogs/RenamePlayerDialogController.ts
@@ -5,7 +5,7 @@ import { Player } from "../../state/TeamState";
 import { RenamePlayerDialogState } from "../../state/RenamePlayerDialogState";
 
 export function renamePlayer(appState: AppState): void {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const renameDialogState: RenamePlayerDialogState | undefined = appState.uiState.dialogState.renamePlayerDialog;
     if (renameDialogState == undefined) {
         return;
@@ -62,11 +62,11 @@ export function validatePlayer(appState: AppState): string | undefined {
         return "Player name cannot be blank";
     }
 
-    if (appState.game.teamNames.indexOf(newPlayer.teamName) === -1) {
+    if (appState.activeGame.teamNames.indexOf(newPlayer.teamName) === -1) {
         return "Team doesn't exist";
     }
 
-    const playersOnTeam: Player[] = [...appState.game.getPlayers(newPlayer.teamName), newPlayer];
+    const playersOnTeam: Player[] = [...appState.activeGame.getPlayers(newPlayer.teamName), newPlayer];
     return NewGameValidator.newPlayerNameUnique(playersOnTeam, trimmedPlayerName);
 }
 

--- a/src/components/dialogs/RenameTeamDialog.tsx
+++ b/src/components/dialogs/RenameTeamDialog.tsx
@@ -50,7 +50,7 @@ const RenameTeamDialogBody = observer(function RenameTeamDialogBody(props: IRena
         return <></>;
     }
 
-    const teamOptions: IDropdownOption[] = appState.game.teamNames.map((teamName, index) => {
+    const teamOptions: IDropdownOption[] = appState.activeGame.teamNames.map((teamName, index) => {
         return {
             key: index,
             text: teamName,

--- a/src/components/dialogs/RenameTeamDialogController.ts
+++ b/src/components/dialogs/RenameTeamDialogController.ts
@@ -3,7 +3,7 @@ import { GameState } from "../../state/GameState";
 import { RenameTeamDialogState } from "../../state/RenameTeamDialogState";
 
 export function renameTeam(appState: AppState): void {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const renameDialogState: RenameTeamDialogState | undefined = appState.uiState.dialogState.renameTeamDialog;
     if (renameDialogState == undefined) {
         return;
@@ -62,7 +62,7 @@ export function validate(appState: AppState): string | undefined {
         return "Name cannot be blank";
     }
 
-    if (appState.game.teamNames.indexOf(renameTeamDialog.newName) >= 0) {
+    if (appState.activeGame.teamNames.indexOf(renameTeamDialog.newName) >= 0) {
         return "Team name already exists";
     }
 

--- a/src/components/dialogs/ReorderPlayerDialog.tsx
+++ b/src/components/dialogs/ReorderPlayerDialog.tsx
@@ -64,7 +64,7 @@ const ReorderPlayerDialogBody = observer(function ReorderPlayerDialogBody(
         return <></>;
     }
 
-    const teamOptions: IDropdownOption[] = appState.game.teamNames.map((teamName, index) => {
+    const teamOptions: IDropdownOption[] = appState.activeGame.teamNames.map((teamName, index) => {
         return {
             key: index,
             text: teamName,

--- a/src/components/dialogs/ReorderPlayersDialogController.ts
+++ b/src/components/dialogs/ReorderPlayersDialogController.ts
@@ -30,7 +30,7 @@ export function movePlayerToIndex(appState: AppState, player: Player, index: num
 }
 
 export function submit(appState: AppState): void {
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     const reorderPlayersDialogState: ReorderPlayersDialogState | undefined =
         appState.uiState.dialogState.reorderPlayersDialog;
     if (reorderPlayersDialogState == undefined) {

--- a/src/components/dialogs/ReorderTeamsDialogController.ts
+++ b/src/components/dialogs/ReorderTeamsDialogController.ts
@@ -4,7 +4,7 @@ import { Player } from "../../state/TeamState";
 import { AppState } from "../../state/AppState";
 
 export function submit(appState: AppState): void {
-    const players: Player[] = [...appState.game.players];
+    const players: Player[] = [...appState.activeGame.players];
     if (players.length < 2) {
         return;
     }
@@ -18,5 +18,5 @@ export function submit(appState: AppState): void {
     players[0] = players[otherPlayerIndex];
     players[otherPlayerIndex] = firstPlayer;
 
-    appState.game.setPlayers(players);
+    appState.activeGame.setPlayers(players);
 }

--- a/src/components/dialogs/ScoresheetDialog.tsx
+++ b/src/components/dialogs/ScoresheetDialog.tsx
@@ -46,7 +46,7 @@ export const ScoresheetDialogBody = observer(function ScoresheetDialogBody(
     props: IScoresheetDialogBodyProps
 ): JSX.Element {
     const appState: AppState = props.appState;
-    const game: GameState = appState.game;
+    const game: GameState = appState.activeGame;
     return (
         <ThemeContext.Consumer>
             {(theme) => {

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -23,6 +23,14 @@ export class AppState {
         this.uiState = new UIState();
     }
 
+    /**
+     * The GameState that gameplay UI should read from and mutate. Today this is always the real game; it exists
+     * as a single indirection point so callers read through one accessor rather than referencing `game` directly.
+     */
+    public get activeGame(): GameState {
+        return this.game;
+    }
+
     // Could do a version with callbacks. There are 4 places this gets called from, and 3 use the same callback
     // Could also just do a bool, and pass in a different value (e.g. enum) if we want more flexibility in the future
     public handleCustomExport(displayType: StatusDisplayType, source: CustomExport.ExportSource): Promise<void> {


### PR DESCRIPTION
Another orthogonal change intended to build towards a "tutorial" mode.

Add the "activeGame" getter to serve as the external-facing interface of the app state. This is currently a passthrough but later it can be reassigned to a dummy state in the tutorial without having to interfere with "this.game"; should be easier to recover after reload, reduce possibility of invalidating real state, etc.