### PR TITLE
Bugfix/replacement bonus tracking

### DIFF
--- a/src/components/ThrowOutQuestionMessage.ts
+++ b/src/components/ThrowOutQuestionMessage.ts
@@ -69,7 +69,7 @@ export function getThrowOutQuestionPrompt(
     const needsMoreQuestions: boolean = nextQuestionNumber > totalQuestionCount;
 
     const scenario: ThrowOutScenario = getScenario(appState, cycleIndex, questionType, gameFormat);
-    const useExplicitProtestReplacement: boolean = scenario === "protest" && questionType === "tossup";
+    const useExplicitProtestReplacement: boolean = scenario === "protest";
 
     let replacementIndex: number | undefined;
     if (needsMoreQuestions) {

--- a/tests/unit/BonusQuestionControllerTests.ts
+++ b/tests/unit/BonusQuestionControllerTests.ts
@@ -105,7 +105,7 @@ describe("BonusQuestionControllerTests", () => {
             expect(appState.game.getBonusIndex(0)).to.equal(2);
         });
 
-        it("Allows multiple sequential thrown out bonuses with later gameplay already recorded", () => {
+        it("Protest bonus throw-out records an explicit replacement and does not shift later cycles", () => {
             const appState: AppState = new AppState();
             appState.game.addNewPlayers([new Player("Alice", "Alpha", true), new Player("Bob", "Beta", true)]);
 
@@ -133,37 +133,47 @@ describe("BonusQuestionControllerTests", () => {
                 3
             );
 
-            // Later gameplay exists, which used to force the bonus throw-out default to the last bonus.
-            appState.game.cycles[1].addWrongBuzz(
-                { player: appState.game.players[1], points: -5, position: 0 },
+            // A later cycle already has its own bonus recorded. Throwing out the first bonus is a protest: that
+            // bonus must be replaced from the end of the packet without disturbing the bonus this cycle answered.
+            const secondCycle: Cycle = appState.game.cycles[1];
+            secondCycle.addCorrectBuzz(
+                { player: appState.game.players[1], points: 10, position: 0 },
                 1,
-                GameFormats.UndefinedGameFormat
+                GameFormats.UndefinedGameFormat,
+                1,
+                3
             );
 
+            expect(appState.game.getBonusIndex(0)).to.equal(0);
+            expect(appState.game.getBonusIndex(1)).to.equal(1);
+
             BonusQuestionController.throwOutBonus(appState, firstCycle, 0);
-            const firstDialog = appState.uiState.dialogState.throwOutQuestionDialog;
-            if (firstDialog == undefined || firstDialog.onConfirm == undefined) {
-                assert.fail("First throw out question dialog should've appeared");
+            const dialog = appState.uiState.dialogState.throwOutQuestionDialog;
+            if (dialog == undefined || dialog.onConfirm == undefined) {
+                assert.fail("Throw out question dialog should've appeared");
             }
 
-            expect(firstDialog.defaultReplacementNumber).to.equal(2);
-            firstDialog.onConfirm(undefined);
-
-            BonusQuestionController.throwOutBonus(appState, firstCycle, 1);
-            const secondDialog = appState.uiState.dialogState.throwOutQuestionDialog;
-            if (secondDialog == undefined || secondDialog.onConfirm == undefined) {
-                assert.fail("Second throw out question dialog should've appeared");
+            // The protest default is the packet's last bonus, recorded explicitly.
+            expect(dialog.defaultReplacementIsExplicit).to.equal(true);
+            expect(dialog.minQuestionNumber).to.equal(2);
+            if (dialog.defaultReplacementNumber == undefined) {
+                assert.fail("Protest bonus throw-out should have a default replacement number");
             }
+            expect(dialog.defaultReplacementNumber).to.equal(4);
 
-            expect(secondDialog.defaultReplacementNumber).to.equal(3);
-            secondDialog.onConfirm(undefined);
+            // Confirming the explicit default sends the 0-based replacement index, as the dialog does.
+            dialog.onConfirm(dialog.defaultReplacementNumber - 1);
 
             if (firstCycle.thrownOutBonuses == undefined) {
                 assert.fail("ThrownOutBonuses was undefined");
             }
 
-            expect(firstCycle.thrownOutBonuses.map((bonus) => bonus.questionIndex)).to.deep.equal([0, 1]);
-            expect(appState.game.getBonusIndex(0)).to.equal(2);
+            expect(firstCycle.thrownOutBonuses[0].questionIndex).to.equal(0);
+            expect(firstCycle.thrownOutBonuses[0].replacementQuestionIndex).to.equal(3);
+
+            // The thrown-out cycle now shows the last bonus, and the later cycle's bonus is unchanged (no shift).
+            expect(appState.game.getBonusIndex(0)).to.equal(3);
+            expect(appState.game.getBonusIndex(1)).to.equal(1);
         });
     });
 });

--- a/tests/unit/ThrowOutQuestionMessageTests.ts
+++ b/tests/unit/ThrowOutQuestionMessageTests.ts
@@ -144,26 +144,32 @@ describe("ThrowOutQuestionMessageTests", () => {
             expect(message).to.contain("replaced with bonus 2");
         });
 
-        it("Bonus with game data after still defaults to sequential replacement", () => {
+        it("Bonus with game data after uses an explicit last-bonus protest replacement", () => {
             const appState: AppState = createAppState();
 
-            // Simulate later gameplay so scenario detection sees data after this cycle.
+            // Simulate later gameplay so scenario detection sees data after this cycle. This is a protest:
+            // the bonuses already read to other teams must not shift, so the replacement is explicit.
             appState.game.cycles[1].addWrongBuzz(
                 { player: players[0], points: -5, position: 0 },
                 1,
                 appState.game.gameFormat
             );
 
-            const { replacementIndex, defaultReplacementIsExplicit } = getThrowOutQuestionPrompt(
+            const { message, replacementIndex, defaultReplacementIsExplicit } = getThrowOutQuestionPrompt(
                 appState,
                 0,
                 "bonus",
                 1
             );
 
-            // Bonus defaults should still move to the next sequential bonus.
-            expect(replacementIndex).to.equal(1);
-            expect(defaultReplacementIsExplicit).to.equal(false);
+            // A protest bonus is replaced by the packet's last bonus (0-based index 3 in the 4-bonus packet),
+            // recorded explicitly so getBonusIndex does not shift subsequent cycles.
+            expect(replacementIndex).to.equal(3);
+            expect(defaultReplacementIsExplicit).to.equal(true);
+
+            // The message must match the replacement it describes, rather than naming a different bonus.
+            expect(message).to.contain("replaced with bonus 4");
+            expect(message).to.contain("protest resolution");
         });
     });
 });


### PR DESCRIPTION
Found a bug while evaluating PR [#407](https://github.com/alopezlago/MODAQ/pull/407). 

Under the "protest" scenario (gameplay recorded after the bonus being thrown out), the bonus replacement is supposed to be explicit and non-shifting. Instead, MODAQ moves all subsequent bonuses up by one, even though the dialog names the last bonus in the packet as the replacement. This is not desired: the replacement bonus may be one teams already heard, and, more importantly, existing bonus points for later cycles become attached to the wrong bonus. 

The cause is that [#407](https://github.com/alopezlago/MODAQ/pull/407) narrowed useExplicitProtestReplacement in ThrowOutQuestionMessage.ts to require questionType to be tossup, excluding bonuses. I dropped that requirement, which fixes the problem, and adjusted a couple of tests to monitor the corrected behavior.