### PR TITLE
Fix YellowFruit tiebreaker export issue

### DIFF
--- a/src/qbj/QBJ.ts
+++ b/src/qbj/QBJ.ts
@@ -589,6 +589,9 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
     let bonusNumber = 1;
     const teamChangesInCycle: Set<string> = new Set<string>();
 
+    // Overtime buzzes, tracked per team and point value for YellowFruit (see IYellowFruitMatchTeamData)
+    const overtimeBuzzCounts: Map<string, Map<number, number>> = new Map<string, Map<number, number>>();
+
     // TODO: Loop until the end of the game, not the number of cycles
     for (let i = 0; i < game.playableCycles.length; i++) {
         const cycle: Cycle = game.playableCycles[i];
@@ -741,12 +744,18 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
             bonus: undefined,
         };
 
+        const isOvertimeCycle: boolean = i >= game.gameFormat.regulationTossupCount;
+
         let isFirstBuzz = true;
         for (const buzz of cycle.orderedBuzzes) {
             const matchBuzz: IMatchQuestionBuzz | undefined = getBuzz(game, teams, buzz, isFirstBuzz);
             if (matchBuzz != undefined) {
                 matchQuestion.buzzes.push(matchBuzz);
                 updateAnswerCount(matchTeams, matchBuzz);
+
+                if (isOvertimeCycle) {
+                    updateOvertimeBuzzCount(overtimeBuzzCounts, matchBuzz);
+                }
             }
 
             isFirstBuzz = false;
@@ -847,9 +856,38 @@ export function toQBJ(game: GameState, packetName?: string, round?: number): IMa
         tossupNumber++;
     }
 
+    // tossups_read counts every tossup read, including overtime ones, so any cycle past the format's regulation
+    // length has to be reported in overtime_tossups_read too. Otherwise stats programs treat the whole game as
+    // regulation and flag it for running longer than the format allows (e.g. a game ending on question 21 in a
+    // 20 tossup format).
+    const overtimeTossupsRead: number = Math.max(
+        0,
+        game.playableCycles.length - game.gameFormat.regulationTossupCount
+    );
+
+    if (overtimeTossupsRead > 0) {
+        // Only include the overtime breakdown when there was overtime, so regular games export the same QBJ as before
+        for (const matchTeam of matchTeams.values()) {
+            const countsByValue: Map<number, number> | undefined = overtimeBuzzCounts.get(matchTeam.team.name);
+            const overTimeBuzzes: IPlayerAnswerCount[] = [];
+
+            // Skip 0 point buzzes. They don't affect the score, and YellowFruit drops them when its rule set has no
+            // matching answer type
+            for (const [value, count] of countsByValue ?? []) {
+                if (value !== 0) {
+                    overTimeBuzzes.push({ answer: { value }, number: count });
+                }
+            }
+
+            // Descending by point value, matching how YellowFruit sorts its own answer counts (powers first)
+            overTimeBuzzes.sort((left, right) => right.answer.value - left.answer.value);
+            matchTeam.YfData = { overTimeBuzzes };
+        }
+    }
+
     const match: IMatch = {
-        // TODO: This should take the format into account, based on how long regular matches should be, plus overtimes
         tossups_read: game.playableCycles.length,
+        overtime_tossups_read: overtimeTossupsRead > 0 ? overtimeTossupsRead : undefined,
         match_teams: [...matchTeams.values()],
         match_questions: matchQuestions,
         notes: noteworthyEvents.length > 0 ? noteworthyEvents.join("\n") : undefined,
@@ -973,10 +1011,24 @@ function updateAnswerCount(matchTeams: Map<string, IMatchTeam>, buzz: IMatchQues
     answerCount.number++;
 }
 
+function updateOvertimeBuzzCount(
+    overtimeBuzzCounts: Map<string, Map<number, number>>,
+    buzz: IMatchQuestionBuzz
+): void {
+    let countsByValue: Map<number, number> | undefined = overtimeBuzzCounts.get(buzz.team.name);
+    if (countsByValue == undefined) {
+        countsByValue = new Map<number, number>();
+        overtimeBuzzCounts.set(buzz.team.name, countsByValue);
+    }
+
+    const points: number = buzz.result.value;
+    countsByValue.set(points, (countsByValue.get(points) ?? 0) + 1);
+}
+
 // Adapted from https://schema.quizbowl.technology/match
 export interface IMatch {
-    tossups_read: number;
-    overtime_tossups_read?: number; //(leave empty for now, until formats are more integrated)
+    tossups_read: number; // Includes overtime tossups
+    overtime_tossups_read?: number; // How many of tossups_read were played in overtime. Omitted when there's no overtime
     match_teams: IMatchTeam[];
     match_questions: IMatchQuestion[];
     notes?: string; // For storing protest info and thrown out Qs
@@ -1000,6 +1052,17 @@ export interface IMatchTeam {
     bonus_bounceback_points?: number;
     match_players: IMatchPlayer[];
     lineups: ILineup[]; // Lineups seen. New entries happen when there are changes in the lineup
+    YfData?: IYellowFruitMatchTeamData;
+}
+
+// Not part of the QBJ spec. YellowFruit checks that an overtime game was tied at the end of regulation by
+// subtracting each team's overtime points from its total, and it only learns those points from this block: its
+// importer never derives them from match_questions, and it writes but never reads correct_tossups_without_bonuses.
+// Without this, every point looks like a regulation point and YellowFruit warns that the score wasn't tied after
+// regulation. See MatchTeam's YfData and FileParsing's parseMatchTeam in https://github.com/ANadig/YellowFruit.
+export interface IYellowFruitMatchTeamData {
+    // YellowFruit tracks these per team rather than per player, since it doesn't record who buzzed in overtime
+    overTimeBuzzes: IPlayerAnswerCount[];
 }
 
 export interface IMatchPlayer {

--- a/tests/unit/QBJTests.ts
+++ b/tests/unit/QBJTests.ts
@@ -2168,6 +2168,148 @@ describe("QBJTests", () => {
                 }
             );
         });
+        it("Export without overtime leaves out overtime_tossups_read", () => {
+            verifyToQBJ(
+                (game) => {
+                    // The packet is shorter than regulation, so no question can be an overtime one
+                    game.setGameFormat(GameFormats.ACFGameFormat);
+                    game.cycles[0].addCorrectBuzz(
+                        { player: firstTeamPlayers[0], points: 10, position: 1 },
+                        0,
+                        game.gameFormat,
+                        0,
+                        3
+                    );
+                },
+                (match) => {
+                    expect(match.tossups_read).to.equal(defaultPacket.tossups.length);
+                    expect(match.overtime_tossups_read).to.be.undefined;
+
+                    // No overtime means no overtime breakdown for YellowFruit either
+                    expect(match.match_teams.every((team) => team.YfData == undefined)).to.be.true;
+                }
+            );
+        });
+        it("Export with sudden death overtime reports the overtime tossups", () => {
+            verifyToQBJ(
+                (game) => {
+                    // Regulation ends after 3 tossups, and overtime is sudden death, so the 4th tossup is overtime
+                    game.setGameFormat({ ...GameFormats.ACFGameFormat, regulationTossupCount: 3 });
+
+                    // Nobody buzzes in regulation, so the game is tied 0-0 and goes to overtime, where the first
+                    // team converts the tiebreaker
+                    game.cycles[3].addCorrectBuzz(
+                        { player: firstTeamPlayers[0], points: 10, position: 1 },
+                        3,
+                        game.gameFormat,
+                        3,
+                        3
+                    );
+                },
+                (match, game) => {
+                    expect(game.playableCycles.length).to.equal(4);
+
+                    // tossups_read includes the overtime tossup, and overtime_tossups_read says how many of those
+                    // weren't regulation questions
+                    expect(match.tossups_read).to.equal(4);
+                    expect(match.overtime_tossups_read).to.equal(1);
+
+                    // YellowFruit needs the overtime buzzes to see that regulation ended tied
+                    expect(match.match_teams[0].YfData?.overTimeBuzzes).to.deep.equal([
+                        { answer: { value: 10 }, number: 1 },
+                    ]);
+                    expect(match.match_teams[1].YfData?.overTimeBuzzes).to.deep.equal([]);
+                }
+            );
+        });
+        it("Export with fixed overtime block reports every overtime tossup", () => {
+            verifyToQBJ(
+                (game) => {
+                    // Regulation ends after 2 tossups, and overtime is played in blocks of 2
+                    game.setGameFormat({
+                        ...GameFormats.ACFGameFormat,
+                        regulationTossupCount: 2,
+                        minimumOvertimeQuestionCount: 2,
+                    });
+
+                    // The game is tied 0-0 after regulation, so both overtime tossups are played even though the
+                    // second team takes the lead on the last one
+                    game.cycles[3].addCorrectBuzz(
+                        { player: secondTeamPlayer, points: 10, position: 1 },
+                        3,
+                        game.gameFormat,
+                        3,
+                        3
+                    );
+                },
+                (match, game) => {
+                    expect(game.playableCycles.length).to.equal(4);
+                    expect(match.tossups_read).to.equal(4);
+                    expect(match.overtime_tossups_read).to.equal(2);
+
+                    // Both overtime tossups count, and only the second team buzzed in them
+                    expect(match.match_teams[0].YfData?.overTimeBuzzes).to.deep.equal([]);
+                    expect(match.match_teams[1].YfData?.overTimeBuzzes).to.deep.equal([
+                        { answer: { value: 10 }, number: 1 },
+                    ]);
+                }
+            );
+        });
+        it("Overtime buzzes include negs, ordered by descending point value", () => {
+            verifyToQBJ(
+                (game) => {
+                    // Regulation ends after 2 tossups, and both tossups of the overtime block are played
+                    game.setGameFormat({
+                        ...GameFormats.StandardPowersMACFGameFormat,
+                        regulationTossupCount: 2,
+                        minimumOvertimeQuestionCount: 2,
+                    });
+
+                    // Tied 0-0 after regulation. The first team negs on the first overtime tossup and converts the
+                    // second, so it has two kinds of overtime buzz
+                    game.cycles[2].addWrongBuzz(
+                        { player: firstTeamPlayers[0], points: -5, position: 0, isLastWord: false },
+                        2,
+                        game.gameFormat
+                    );
+                    game.cycles[3].addCorrectBuzz(
+                        { player: firstTeamPlayers[0], points: 10, position: 1 },
+                        3,
+                        game.gameFormat,
+                        3,
+                        3
+                    );
+                },
+                (match, game) => {
+                    expect(game.playableCycles.length).to.equal(4);
+                    expect(match.overtime_tossups_read).to.equal(2);
+
+                    // Powers first, negs last, matching how YellowFruit sorts answer counts
+                    expect(match.match_teams[0].YfData?.overTimeBuzzes).to.deep.equal([
+                        { answer: { value: 10 }, number: 1 },
+                        { answer: { value: -5 }, number: 1 },
+                    ]);
+                    expect(match.match_teams[1].YfData?.overTimeBuzzes).to.deep.equal([]);
+
+                    // The regulation score YellowFruit derives (total minus overtime) is tied, which is what stops
+                    // the "score wasn't tied after regulation" warning
+                    const regulationScores: number[] = match.match_teams.map((team) => {
+                        const total: number = team.match_players.reduce(
+                            (sum, player) =>
+                                sum +
+                                player.answer_counts.reduce((count, ac) => count + ac.answer.value * ac.number, 0),
+                            team.bonus_points
+                        );
+                        const overtimePoints: number = (team.YfData?.overTimeBuzzes ?? []).reduce(
+                            (sum, ac) => sum + ac.answer.value * ac.number,
+                            0
+                        );
+                        return total - overtimePoints;
+                    });
+                    expect(regulationScores[0]).to.equal(regulationScores[1]);
+                }
+            );
+        });
     });
     describe("parseRegistration", () => {
         function verifyRegistration(tournament: ITournament, verify: (players: Player[]) => void) {


### PR DESCRIPTION
YellowFruit complains about imported games with tiebreakers and requires several unintuitive changes in the number tossups heard, points, etc. to fix the import. This changes the export for tiebreakers to deal with that